### PR TITLE
feat: slo-exporter --version command-line flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v6.4.0] 2020-08-07
 ## Added
-- [#25](https://github.com/seznam/slo-exporter/pull/25) --version command-line flag
+- [#25](https://github.com/seznam/slo-exporter/pull/25) `--version` command-line flag showing only the build version
 
 ## [v6.3.0] 2020-08-05
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v6.4.0] 2020-08-07
+## Added
+- [#25](https://github.com/seznam/slo-exporter/pull/25) --version command-line flag
+
 ## [v6.3.0] 2020-08-05
 ## Added
 - [#24](https://github.com/seznam/slo-exporter/pull/24) DynamicClassifier: Allow use of comments in the CSV files, see [the docs](./docs/modules/dynamic_classifier.md#csv-comments).

--- a/cmd/slo_exporter.go
+++ b/cmd/slo_exporter.go
@@ -128,10 +128,23 @@ func main() {
 	runtime.SetBlockProfileRate(1)
 	runtime.SetMutexProfileFraction(1)
 
-	configFilePath := kingpin.Flag("config-file", "SLO exporter configuration file.").Required().ExistingFile()
+	configFilePath := kingpin.Flag("config-file", "SLO exporter configuration file.").ExistingFile()
 	logLevel := kingpin.Flag("log-level", "Log level (error, warn, info, debug,trace).").Default("info").String()
 	checkConfig := kingpin.Flag("check-config", "Only check config file and exit with 0 if ok and other status code if not.").Default("false").Bool()
+	versionFlag := kingpin.Flag("version", "Display version.").Default("false").Bool()
 	kingpin.Parse()
+
+	// If version is requested, end here.
+	if *versionFlag {
+		fmt.Printf("slo_exporter version %s (from commit %s at %s by %s)\n", version, commit, date, builtBy)
+		return
+	}
+
+	if *configFilePath == "" {
+		fmt.Fprintln(os.Stderr, "error: required flag --config-file not provided, try --help")
+		os.Exit(1)
+	}
+
 	envLogLevel, ok := syscall.Getenv("SLO_EXPORTER_LOGLEVEL")
 	if ok {
 		logLevel = &envLogLevel
@@ -153,7 +166,7 @@ func main() {
 		logger.Fatalf("failed to initialize the pipeline: %v", err)
 	}
 
-	// If only  configuration check is required, end here.
+	// If configuration check is required, end here.
 	if *checkConfig {
 		logger.Info("Configuration is valid!")
 		return


### PR DESCRIPTION
## what is wrong
* Currently we are unable to easily identify version of the tool
* Contribution guide suggests, slo-exporter should have `--version` command-line flag to be reported back in case of bugs.

## the proposed change
* This PR adds `--version` command-line flag to help user to identify what version they actually use.