### PR TITLE
empty config should be invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v6.4.1] 2020-08-25
 ## Fixed
 - [#27](https://github.com/seznam/slo-exporter/pull/27) Empty configuration is now evaluated as invalid
 
@@ -24,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#18](https://github.com/seznam/slo-exporter/pull/18) Tailer: Upgraded hpcloud/tail package to latest commit.
 
 ## Added
-- [#20](https://github.com/seznam/slo-exporter/pull/20) CI: 
+- [#20](https://github.com/seznam/slo-exporter/pull/20) CI:
      - Release additional Docker image tags:
         - `latest` Latest released version.
         - `vX` Latest released version for the major version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Fixed
-- [#26](https://github.com/seznam/slo-exporter/pull/26) Empty configuration is now evaluated as invalid
+- [#27](https://github.com/seznam/slo-exporter/pull/27) Empty configuration is now evaluated as invalid
 
 ## [v6.4.0] 2020-08-07
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- [#26](https://github.com/seznam/slo-exporter/pull/26) Empty configuration is now evaluated as invalid
 
 ## [v6.4.0] 2020-08-07
 ## Added

--- a/cmd/slo_exporter.go
+++ b/cmd/slo_exporter.go
@@ -199,8 +199,10 @@ func main() {
 	}
 	pipelineManager.RegisterWebInterface(router)
 
-	// Start the pipeline items `processing
-	pipelineManager.StartPipeline()
+	// Start the pipeline processing
+	if err := pipelineManager.StartPipeline(); err != nil {
+		logger.Fatalf("failed to start the pipeline: %v", err)
+	}
 
 	// listen for OS signals
 	sigChan := make(chan os.Signal, 3)

--- a/pkg/pipeline/manager.go
+++ b/pkg/pipeline/manager.go
@@ -28,6 +28,9 @@ func NewManager(moduleFactory moduleFactoryFunction, config *config.Config, logg
 		pipeline: []pipelineItem{},
 		logger:   logger,
 	}
+	if len(config.Pipeline) < 1 {
+		return nil, fmt.Errorf("failed to create the pipeline as no modules defined in the config")
+	}
 	// Initialize the pipeline and link it together.
 	for _, moduleName := range config.Pipeline {
 		newPipelineItem, err := manager.newPipelineItem(moduleName, config, moduleFactory)

--- a/pkg/pipeline/manager.go
+++ b/pkg/pipeline/manager.go
@@ -6,8 +6,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/iancoleman/strcase"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 	"github.com/seznam/slo-exporter/pkg/config"
+	"github.com/sirupsen/logrus"
 	"strings"
 	"time"
 )
@@ -59,14 +59,14 @@ func (m *Manager) StartPipeline() error {
 	if len(m.pipeline) == 0 {
 		return fmt.Errorf("failed to execute the empty pipeline (no pipeline modules defined in the config)")
 	}
-    var pipelineSchema []string
+	var pipelineSchema []string
 	for _, pipelineItem := range m.pipeline {
 		pipelineItem.module.Run()
 		pipelineSchema = append(pipelineSchema, pipelineItem.name)
 	}
 	m.logger.Info("pipeline schema: " + strings.Join(pipelineSchema, " -> "))
 	m.logger.Info("pipeline started")
-  return nil
+	return nil
 }
 
 func (m *Manager) StopPipeline(ctx context.Context) chan struct{} {

--- a/pkg/pipeline/manager.go
+++ b/pkg/pipeline/manager.go
@@ -28,9 +28,6 @@ func NewManager(moduleFactory moduleFactoryFunction, config *config.Config, logg
 		pipeline: []pipelineItem{},
 		logger:   logger,
 	}
-	if len(config.Pipeline) < 1 {
-		return nil, fmt.Errorf("failed to create the pipeline as no modules defined in the config")
-	}
 	// Initialize the pipeline and link it together.
 	for _, moduleName := range config.Pipeline {
 		newPipelineItem, err := manager.newPipelineItem(moduleName, config, moduleFactory)
@@ -56,16 +53,20 @@ type Manager struct {
 	logger   logrus.FieldLogger
 }
 
-func (m *Manager) StartPipeline() {
+func (m *Manager) StartPipeline() error {
 	m.logger.Info("starting pipeline... ")
-	var pipelineSchema []string
+
+	if len(m.pipeline) == 0 {
+		return fmt.Errorf("failed to execute the empty pipeline (no pipeline modules defined in the config)")
+	}
+    var pipelineSchema []string
 	for _, pipelineItem := range m.pipeline {
 		pipelineItem.module.Run()
 		pipelineSchema = append(pipelineSchema, pipelineItem.name)
 	}
 	m.logger.Info("pipeline schema: " + strings.Join(pipelineSchema, " -> "))
 	m.logger.Info("pipeline started")
-
+  return nil
 }
 
 func (m *Manager) StopPipeline(ctx context.Context) chan struct{} {

--- a/pkg/pipeline/manager_test.go
+++ b/pkg/pipeline/manager_test.go
@@ -41,8 +41,16 @@ func (t *testModule) OutputChannel() chan *event.Raw {
 	return make(chan *event.Raw)
 }
 
-func newTestManager() (*Manager, error) {
+func newEmptyManager() (*Manager, error) {
 	manager, err := NewManager(testModuleFactory, &config.Config{Pipeline: []string{},}, logrus.New())
+	if err != nil {
+		return nil, err
+	}
+	return manager, nil
+}
+
+func newTestManager() (*Manager, error) {
+	manager, err := newEmptyManager()
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +76,15 @@ test_module_test 0
 
 	err = testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics))
 	assert.NoError(t, err)
+}
+
+
+// Empty pipeline refuses to start
+func TestManager_StartEmptyPipeline(t *testing.T) {
+	manager, err := newEmptyManager()
+	assert.NoError(t, err)
+	err = manager.StartPipeline()
+	assert.Error(t, err)
 }
 
 func TestManager_StartPipeline(t *testing.T) {

--- a/pkg/pipeline/manager_test.go
+++ b/pkg/pipeline/manager_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/seznam/slo-exporter/pkg/config"
+	"github.com/seznam/slo-exporter/pkg/event"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"github.com/seznam/slo-exporter/pkg/config"
-	"github.com/seznam/slo-exporter/pkg/event"
 	"strings"
 	"testing"
 )
@@ -42,7 +42,7 @@ func (t *testModule) OutputChannel() chan *event.Raw {
 }
 
 func newEmptyManager() (*Manager, error) {
-	manager, err := NewManager(testModuleFactory, &config.Config{Pipeline: []string{},}, logrus.New())
+	manager, err := NewManager(testModuleFactory, &config.Config{Pipeline: []string{}}, logrus.New())
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,6 @@ test_module_test 0
 	err = testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics))
 	assert.NoError(t, err)
 }
-
 
 // Empty pipeline refuses to start
 func TestManager_StartEmptyPipeline(t *testing.T) {


### PR DESCRIPTION
## Why is this fix needed?

Resolves #26 

## Fix idea

Let Pipeline manager to throw an error when empty pipeline is getting started.
Normal error propagation used although panic could be an option as well.
