### PR TITLE
fix: prometheus-ingester query_fails_total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - [#28](https://github.com/seznam/slo-exporter/pull/28) Abstracted statistical classifier history to generic interface in new storage package.
 
+## Fixed
+- [#33](https://github.com/seznam/slo-exporter/pull/33) prometheus-ingester now always expose query_fails_total
+
 ## [v6.4.1] 2020-08-25
 ## Fixed
 - [#27](https://github.com/seznam/slo-exporter/pull/27) Empty configuration is now evaluated as invalid

--- a/pkg/prometheus_ingester/query_executor.go
+++ b/pkg/prometheus_ingester/query_executor.go
@@ -83,6 +83,9 @@ func (q *queryExecutor) run(ctx context.Context, wg *sync.WaitGroup) {
 	defer ticker.Stop()
 	defer wg.Done()
 
+	// make sure that this metric is exposed even when no errors have been experienced
+	prometheusQueryFail.WithLabelValues(string(q.Query.Type)).Add(0)
+
 	for {
 		select {
 		// Wait for the tick


### PR DESCRIPTION
Prometheus-ingester now always expose query_fails_total metric, even when eq 0. This simplifies use of this metric in promql computation - e.g. calculation SLO violation ratio for prometheus-ingester queries, as shown in [all-in-one example](https://github.com/seznam/slo-exporter/blob/master/prometheus/recording_rules/events-over-time-slo-exporter.yaml).