### PR TITLE
New ingester module: Envoy access-log-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- [#37](https://github.com/seznam/slo-exporter/pull/37) New ingester module [`envoyAccessLogServer`](docs/modules/envoy_access_log_server.md) to receive remote [access logs from an Envoy proxy over the gRPC](https://www.envoyproxy.io/docs/envoy/latest/api-v3/data/accesslog/v3/accesslog.proto).
+
 ## Fixed
 - [#39](https://github.com/seznam/slo-exporter/pull/39) Prometheus-exporter: Additional SLO event metadata does not get overwritten.
 

--- a/cmd/slo_exporter.go
+++ b/cmd/slo_exporter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/seznam/slo-exporter/pkg/config"
 	"github.com/seznam/slo-exporter/pkg/dynamic_classifier"
+	"github.com/seznam/slo-exporter/pkg/envoy_access_log_server"
 	"github.com/seznam/slo-exporter/pkg/event_key_generator"
 	"github.com/seznam/slo-exporter/pkg/metadata_classifier"
 	"github.com/seznam/slo-exporter/pkg/pipeline"
@@ -63,6 +64,8 @@ func moduleFactory(moduleName string, logger logrus.FieldLogger, conf *viper.Vip
 		return tailer.NewFromViper(conf, logger)
 	case "prometheusIngester":
 		return prometheus_ingester.NewFromViper(conf, logger)
+	case "envoyAccessLogServer":
+		return envoy_access_log_server.NewFromViper(conf, logger)
 	case "relabel":
 		return relabel.NewFromViper(conf, logger)
 	case "eventKeyGenerator":

--- a/docs/modules/envoy_access_log_server.md
+++ b/docs/modules/envoy_access_log_server.md
@@ -1,0 +1,125 @@
+# Envoy access log server
+
+|                |                        |
+|----------------|------------------------|
+| `moduleName`   | `envoyAccessLogServer` |
+| Module type    | `producer`             |
+| Output event   | `raw`                  |
+
+This module allows you to generate events based on access logs sent form remote [Envoy proxy](https://www.envoyproxy.io/) over a gRPC interface.
+
+### Envoy support and configuration
+At this moment, V3 of envoy's xDS API is supported. [See the upstream documentation for details](https://www.envoyproxy.io/docs/envoy/latest/api/api_supported_versions) on API versions.
+
+In particular, you have to configure your envoy instance to send access_logs using [v3 AccessLogService rpc](https://github.com/envoyproxy/envoy/blob/842485709d651a6057b2ffb505ffced21173e004/api/envoy/service/accesslog/v3/als.proto#L39). We currently do not implement handling of other versions.
+
+See a minimal example on how to configure envoy to send access_logs to an slo-exporter instance (envoy v1.15+):
+
+```yaml
+static_resources:
+  listeners:
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8080
+    filter_chains:
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          access_log:
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig
+              common_config:
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: service_accesslog
+                buffer_size_bytes:
+                  value: 0
+                log_name: accesslogv3
+                transport_api_version: V3 # needed to ensure that v3.AccessLogService is used
+              additional_request_headers_to_log: ['slo-result', 'slo-class', 'slo-app', 'slo-endpoint']
+          http_filters: [...]
+  clusters:
+    connect_timeout: 6s
+    type: LOGICAL_DNS
+    load_assignment:
+      cluster_name: service_accesslog
+      endpoints:
+            address:
+              socket_address:
+                address: localhost
+                port_value: 18090
+    http2_protocol_options: {}
+    ...
+```
+
+### Resulting event metadata
+Please note that some of the keys may not be present	|
+
+#### Common properties
+| metadata's key                    |  example(s)            | description |
+|-----------------------------------|------------------------|-------------|
+| downstreamDirectRemoteAddress     | `77.75.74.172`, `2a02:598:3333:1::1` | IP address (v4 or v6) |
+| downstreamDirectRemotePort	    | `443` | TCP port number |
+| downstreamLocalAddress	        | `77.75.74.172`, `2a02:598:3333:1::1` | IP address (v4 or v6) |
+| downstreamLocalPort               | `443` | TCP port number |
+| downstreamRemoteAddress	        | `77.75.74.172`, `2a02:598:3333:1::1` | IP address (v4 or v6) |
+| downstreamRemotePort	            | `443` | TCP port number |
+| routeName                         | `fooRoute` | Name of the route as present in an envoy's configuration |
+| sampleRate	                    | `1.0`, `0.0` | Indicates the rate at which this log entry was sampled. Valid range is (0.0, 1.0].
+| startTime	                        | RFC3339 `2020-12-22T14:27:28Z` | The time that Envoy started servicing this request.
+| timeToFirstDownstreamTxByte       | `32451342ns` | Interval between the first downstream byte received and the first downstream byte sent.
+| timeToFirstUpstreamRxByte	        | `32451342ns` | Interval between the first downstream byte received and the first upstream byte received (i.e. time it takes to start receiving a response).
+| timeToFirstUpstreamTxByte	        | `32451342ns` | Interval between the first downstream byte received and the first upstream byte sent. |
+| timeToLastDownstreamTxByte        | `32451342ns` | Interval between the first downstream byte received and the last downstream byte sent. |
+| timeToLastRxByte	                | `32451342ns` | Interval between the first downstream byte received and the last downstream byte received (i.e. time it takes to receive a request). |
+| timeToLastUpstreamRxByte	        | `32451342ns` | Interval between the first downstream byte received and the last upstream byte received (i.e. time it takes to receive a complete response). |
+| timeToLastUpstreamTxByte          | `32451342ns` | Interval between the first downstream byte received and the last upstream byte sent. |
+| upstreamCluster                   | `fooUpstream` | Name of the upstream cluster as present in an envoy's configuration |
+| upstreamLocalAddress              | `77.75.74.172`, `2a02:598:3333:1::1` | IP address (v4 or v6) |
+| upstreamLocalPort                 | `443` | TCP port number |
+| upstreamRemoteAddress	            | `77.75.74.172`, `2a02:598:3333:1::1` | IP address (v4 or v6) |
+| upstreamRemotePort	            | `443` | TCP port number |
+| upstreamTransportFailureReason    | "TLS handshake" | [%UPSTREAM_TRANSPORT_FAILURE_REASON%](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage) |
+
+*Note: please see [envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage) on explanation on how *RemoteAddress,*ReportPort is filled.*
+
+#### HTTP access_log request properties
+| metadata's key                    |  example(s)            | description |
+|-----------------------------------|------------------------|-------------|
+| authority     | `neverssl.com`, `neverssl.com:80` | HTTP/2 `authority` or HTTP/1.1 `Host` header value. |
+| forwardedFor  | `203.0.113.195, 70.41.3.18, 150.172.238.178` | X-Forwarded-For HTTP header |
+| originalPath  | `/` | Value of the ``X-Envoy-Original-Path`` request header. |
+| path          | `/` | The path portion from the incoming request URI. |
+| referer       | `Referer: https://www.seznam.cz` | Value of the `Referer` request header. |
+| http_*request_header_name* e.g. `http_slo-domain` | `userportal` | Request's HTTP header |
+| requestBodyBytes      | `32` ||
+| requestHeadersBytes   | `32` ||
+| requestId             | `e087fb8b-ee2f-4d92-bb83-afdabc8cceee` | Value of the ``X-Request-Id`` request header |
+| requestMethod         | `GET` | HTTP method name |
+| scheme                | `http` | The scheme portion of the incoming request URI. |
+| userAgent             | `curl/7.74.0-DEV` | Value of the `User-Agent` request header. |
+
+#### HTTP access_log response properties
+| metadata's key                    |  example(s)            | description |
+|-----------------------------------|------------------------|-------------|
+| responseBodyBytes | `32` ||
+| responseCodeDetails | `via_upstream` | The HTTP response code details. |
+| responseCode | `200` | HTTP response code |
+| responseHeadersBytes | `32` ||
+| sent_http_*response_header_name* (e.g. `sent_http_slo-domain`) | `userportal` | Response's HTTP header |
+| sent_trailer_*trailer_name* (e.g. `sent_trailer_slo-result`)   | `success` | Response's HTTP trailer |
+
+#### TCP access_log properties
+| metadata's key                    |  example(s)            | description |
+|-----------------------------------|------------------------|-------------|
+| receivedBytes | `32` ||
+| sentBytes | `32` ||
+
+### moduleConfig
+```yaml
+# IP address and port for GRPC server to bind to. See [net.Listen](https://golang.org/pkg/net/#Listen) on details of TCP network's possible representation of an address.
+address: ":18090"
+# gracefulShutdownTimeout for the GRPC server. Please note also the existence of 'maximumGracefulShutdownDuration' global config option which is effectively an upper boundary of here-specified timeout value.
+gracefulShutdownTimeout: "5s"
+```

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,17 @@ module github.com/seznam/slo-exporter
 go 1.15
 
 require (
+	github.com/envoyproxy/go-control-plane v0.9.8
 	github.com/go-kit/kit v0.10.0
 	github.com/go-test/deep v1.0.6
+	github.com/golang/protobuf v1.4.2
 	github.com/gorilla/mux v1.7.4
 	github.com/grafana/loki v1.5.0
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hpcloud/tail v1.0.1-0.20180514194441-a1dbeea552b7
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.6.0
 	github.com/prometheus/common v0.10.0
 	github.com/prometheus/prometheus v1.8.2-0.20200213233353-b90be6f32a33
@@ -20,6 +24,8 @@ require (
 	golang.org/x/sys v0.0.0-20200828194041-157a740278f4 // indirect
 	golang.org/x/tools v0.0.0-20200828161849-5deb26317202 // indirect
 	gonum.org/v1/gonum v0.7.0
+	google.golang.org/grpc v1.27.0
+	google.golang.org/protobuf v1.23.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190531201743-edce55837238/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
@@ -198,6 +200,9 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.8 h1:bbmjRkjmP0ZggMoahdNMmJFFnK7v5H+/j5niP5QH6bg=
+github.com/envoyproxy/go-control-plane v0.9.8/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
@@ -325,6 +330,8 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
+github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
@@ -387,6 +394,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 h1:THDBEeQ9xZ8JEaCLyLQqXMMdRqNr0QAUJTIkQAUtFjg=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340 h1:uGoIog/wiQHI9GAxXO5TJbT0wWKH3O9HhOJW1F9c3fY=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340/go.mod h1:3bDW6wMZJB7tiONtC/1Xpicra6Wp5GgbTbQWCbI5fkc=
 github.com/grpc-ecosystem/grpc-gateway v1.4.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -1113,12 +1121,16 @@ google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRn
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
+google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
+google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/pkg/envoy_access_log_server/access_log_server.go
+++ b/pkg/envoy_access_log_server/access_log_server.go
@@ -1,0 +1,135 @@
+package envoy_access_log_server
+
+import (
+	"fmt"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/seznam/slo-exporter/pkg/event"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+	"net"
+	"time"
+)
+
+var (
+	logEntriesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "processed_logentries_total",
+		Help: "Total number of processed log entries.",
+	}, []string{"protocol", "api_version"})
+
+	errorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "errors_total",
+		Help: "Errors while processing the received logs.",
+	}, []string{"type"})
+	serverMetrics *grpc_prometheus.ServerMetrics
+)
+
+type accessLogServerConfig struct {
+	Address                 string
+	GracefulShutdownTimeout time.Duration
+}
+
+type AccessLogServer struct {
+	outputChannel           chan *event.Raw
+	logger                  logrus.FieldLogger
+	done                    bool
+	server                  *grpc.Server
+	service_v3              *AccessLogServiceV3
+	address                 string
+	gracefulShutdownTimeout time.Duration
+}
+
+func init() {
+	serverMetrics = grpc_prometheus.NewServerMetrics()
+}
+
+func (als *AccessLogServer) String() string {
+	return "envoyAccessLogServer"
+}
+
+func NewFromViper(viperConfig *viper.Viper, logger logrus.FieldLogger) (*AccessLogServer, error) {
+	viperConfig.SetDefault("address", ":18090")
+	viperConfig.SetDefault("gracefulShutdownTimeout", 5*time.Second)
+	var config accessLogServerConfig
+	if err := viperConfig.UnmarshalExact(&config); err != nil {
+		return nil, fmt.Errorf("failed to load configuration: %w", err)
+	}
+	return New(config, logger)
+}
+
+// New returns an instance of AccessLogServer
+func New(config accessLogServerConfig, logger logrus.FieldLogger) (*AccessLogServer, error) {
+	als := AccessLogServer{
+		outputChannel:           make(chan *event.Raw),
+		logger:                  logger,
+		address:                 config.Address,
+		gracefulShutdownTimeout: config.GracefulShutdownTimeout,
+	}
+	return &als, nil
+}
+
+func (als *AccessLogServer) Run() {
+	listen, err := net.Listen("tcp", als.address)
+	if err != nil {
+		als.logger.Fatalf("Error while starting the %s: %v", als, err)
+	}
+	als.server = grpc.NewServer(
+		grpc.StreamInterceptor(serverMetrics.StreamServerInterceptor()),
+	)
+
+	als.service_v3 = &AccessLogServiceV3{
+		outChan: als.outputChannel,
+		logger:  als.logger.WithField("EnvoyApiVersion", "3"),
+	}
+	als.service_v3.Register(als.server)
+
+	serverMetrics.InitializeMetrics(als.server)
+
+	// Start the server
+	go func() {
+		err = als.server.Serve(listen)
+		if err != nil {
+			als.logger.Errorf("%s GRPC server fatal error, initiating graceful shutdown: %v", als, err)
+			als.Stop()
+		}
+	}()
+}
+
+func (als *AccessLogServer) Stop() {
+	go func() {
+		// Initiate the server shutdown
+		stopped := make(chan struct{})
+		go func() {
+			als.server.GracefulStop()
+			close(stopped)
+		}()
+		t := time.NewTimer(als.gracefulShutdownTimeout)
+		select {
+		case <-t.C:
+		case <-stopped:
+		}
+		als.server.Stop()
+		close(als.outputChannel)
+		als.done = true
+	}()
+}
+
+func (als *AccessLogServer) Done() bool {
+	return als.done
+}
+
+func (als *AccessLogServer) RegisterMetrics(_ prometheus.Registerer, wrappedRegistry prometheus.Registerer) error {
+	toRegister := []prometheus.Collector{logEntriesTotal, errorsTotal}
+	for _, collector := range toRegister {
+		if err := wrappedRegistry.Register(collector); err != nil {
+			return fmt.Errorf("error registering metric %s: %w", collector, err)
+		}
+	}
+	wrappedRegistry.Register(serverMetrics)
+	return nil
+}
+
+func (als *AccessLogServer) OutputChannel() chan *event.Raw {
+	return als.outputChannel
+}

--- a/pkg/envoy_access_log_server/service_v3.go
+++ b/pkg/envoy_access_log_server/service_v3.go
@@ -1,0 +1,262 @@
+package envoy_access_log_server
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	envoy_data_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v3"
+	envoy_service_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v3"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+
+	"github.com/seznam/slo-exporter/pkg/event"
+	"github.com/seznam/slo-exporter/pkg/stringmap"
+)
+
+type AccessLogServiceV3 struct {
+	outChan chan *event.Raw
+	logger  logrus.FieldLogger
+	envoy_service_accesslog_v3.UnimplementedAccessLogServiceServer
+}
+
+type envoyV3AccessLogEntryCommonProperties envoy_data_accesslog_v3.AccessLogCommon
+
+func (p envoyV3AccessLogEntryCommonProperties) StringMap(logger logrus.FieldLogger) stringmap.StringMap {
+	m := stringmap.StringMap{}
+
+	if p.DownstreamDirectRemoteAddress != nil {
+		if sa := p.DownstreamDirectRemoteAddress.GetSocketAddress(); sa != nil {
+			m["downstreamDirectRemoteAddress"] = sa.GetAddress()
+			m["downstreamDirectRemotePort"] = fmt.Sprint(sa.GetPortValue())
+		} else {
+			logger.Warnf("%s address is in unsupported format", "DownstreamDirectRemoteAddress")
+			errorsTotal.WithLabelValues("AddressFormatUnsupported").Inc()
+		}
+	}
+	if p.DownstreamRemoteAddress != nil {
+		if sa := p.DownstreamRemoteAddress.GetSocketAddress(); sa != nil {
+			m["downstreamRemoteAddress"] = sa.GetAddress()
+			m["downstreamRemotePort"] = fmt.Sprint(sa.GetPortValue())
+		} else {
+			logger.Warnf("%s address is in unsupported format", "DownstreamRemoteAddress")
+			errorsTotal.WithLabelValues("AddressFormatUnsupported").Inc()
+		}
+	}
+	if p.DownstreamLocalAddress != nil {
+		if sa := p.DownstreamLocalAddress.GetSocketAddress(); sa != nil {
+			m["downstreamLocalAddress"] = sa.GetAddress()
+			m["downstreamLocalPort"] = fmt.Sprint(sa.GetPortValue())
+		} else {
+			logger.Warnf("%s address is in unsupported format", "DownstreamLocalAddress")
+			errorsTotal.WithLabelValues("AddressFormatUnsupported").Inc()
+		}
+	}
+	m["routeName"] = p.RouteName
+	if ts := p.StartTime; ts != nil {
+		if t, err := ptypes.Timestamp(ts); err == nil {
+			m["startTime"] = t.Format(time.RFC3339)
+		} else {
+			logger.Warnf("Unable to parse %s timestamp", "StartTime")
+			errorsTotal.WithLabelValues("InvalidTimestamp").Inc()
+		}
+	}
+	if p.TimeToFirstDownstreamTxByte != nil {
+		if duration, err := pbDurationDeterministicString(p.TimeToFirstDownstreamTxByte); err == nil {
+			m["timeToFirstDownstreamTxByte"] = duration
+		} else {
+			logger.Warnf("Unable to parse %s duration", "TimeToFirstDownstreamTxByte")
+			errorsTotal.WithLabelValues("InvalidDuration").Inc()
+		}
+	}
+	if p.TimeToFirstUpstreamRxByte != nil {
+		if duration, err := pbDurationDeterministicString(p.TimeToFirstUpstreamRxByte); err == nil {
+			m["timeToFirstUpstreamRxByte"] = duration
+		} else {
+			logger.Warnf("Unable to parse %s duration", "TimeToFirstUpstreamRxByte")
+			errorsTotal.WithLabelValues("InvalidDuration").Inc()
+		}
+	}
+	if p.TimeToFirstUpstreamTxByte != nil {
+		if duration, err := pbDurationDeterministicString(p.TimeToFirstUpstreamTxByte); err == nil {
+			m["timeToFirstUpstreamTxByte"] = duration
+		} else {
+			logger.Warnf("Unable to parse %s duration", "TimeToFirstUpstreamTxByte")
+			errorsTotal.WithLabelValues("InvalidDuration").Inc()
+		}
+	}
+	if p.TimeToLastDownstreamTxByte != nil {
+		if duration, err := pbDurationDeterministicString(p.TimeToLastDownstreamTxByte); err == nil {
+			m["timeToLastDownstreamTxByte"] = duration
+		} else {
+			logger.Warnf("Unable to parse %s duration", "TimeToLastDownstreamTxByte")
+			errorsTotal.WithLabelValues("InvalidDuration").Inc()
+		}
+	}
+	if p.TimeToLastRxByte != nil {
+		if duration, err := pbDurationDeterministicString(p.TimeToLastRxByte); err == nil {
+			m["timeToLastRxByte"] = duration
+		} else {
+			logger.Warnf("Unable to parse %s duration", "TimeToLastRxByte")
+			errorsTotal.WithLabelValues("InvalidDuration").Inc()
+		}
+	}
+	if p.TimeToLastUpstreamRxByte != nil {
+		if duration, err := pbDurationDeterministicString(p.TimeToLastUpstreamRxByte); err == nil {
+			m["timeToLastUpstreamRxByte"] = duration
+		} else {
+			logger.Warnf("Unable to parse %s duration", "TimeToLastUpstreamRxByte")
+			errorsTotal.WithLabelValues("InvalidDuration").Inc()
+		}
+	}
+	if p.TimeToLastUpstreamTxByte != nil {
+		if duration, err := pbDurationDeterministicString(p.TimeToLastUpstreamTxByte); err == nil {
+			m["timeToLastUpstreamTxByte"] = duration
+		} else {
+			logger.Warnf("Unable to parse %s duration", "TimeToLastUpstreamTxByte")
+			errorsTotal.WithLabelValues("InvalidDuration").Inc()
+		}
+	}
+	m["upstreamCluster"] = p.UpstreamCluster
+	if p.UpstreamLocalAddress != nil {
+		if sa := p.UpstreamLocalAddress.GetSocketAddress(); sa != nil {
+			m["upstreamLocalAddress"] = sa.GetAddress()
+			m["upstreamLocalPort"] = fmt.Sprint(sa.GetPortValue())
+		} else {
+			logger.Warnf("%s address is in unsupported format", "UpstreamLocalAddress")
+			errorsTotal.WithLabelValues("AddressFormatUnsupported").Inc()
+		}
+	}
+	if p.UpstreamRemoteAddress != nil {
+		if sa := p.UpstreamRemoteAddress.GetSocketAddress(); sa != nil {
+			m["upstreamRemoteAddress"] = sa.GetAddress()
+			m["upstreamRemotePort"] = fmt.Sprint(sa.GetPortValue())
+		} else {
+			logger.Warnf("%s address is in unsupported format", "UpstreamRemoteAddress")
+			errorsTotal.WithLabelValues("AddressFormatUnsupported").Inc()
+		}
+	}
+	m["upstreamTransportFailureReason"] = p.UpstreamTransportFailureReason
+	m["sampleRate"] = strconv.FormatFloat(p.SampleRate, 'f', -1, 64)
+
+	return m
+}
+
+type envoyV3AccessLogEntryHttpRequestProperties envoy_data_accesslog_v3.HTTPRequestProperties
+
+func (request envoyV3AccessLogEntryHttpRequestProperties) StringMap(logger logrus.FieldLogger) stringmap.StringMap {
+	result := stringmap.StringMap{}
+
+	result["authority"] = request.Authority
+	result["forwardedFor"] = request.ForwardedFor
+	result["originalPath"] = request.OriginalPath
+	result["path"] = request.Path
+	result["referer"] = request.Referer
+
+	// request headers are encoded with `http_` prefix (to keep the scheme used by Nginx)
+	if request.RequestHeaders != nil {
+		for header_name, header_value := range request.RequestHeaders {
+			result["http_"+header_name] = header_value
+		}
+	}
+
+	result["requestBodyBytes"] = strconv.FormatUint(request.RequestBodyBytes, 10)
+	result["requestHeadersBytes"] = strconv.FormatUint(request.RequestHeadersBytes, 10)
+	result["requestId"] = request.RequestId
+	result["requestMethod"] = request.RequestMethod.String()
+	result["scheme"] = request.Scheme
+	result["userAgent"] = request.UserAgent
+
+	return result
+}
+
+type envoyV3AccessLogEntryHttpResponseProperties envoy_data_accesslog_v3.HTTPResponseProperties
+
+func (response envoyV3AccessLogEntryHttpResponseProperties) StringMap(logger logrus.FieldLogger) stringmap.StringMap {
+	result := stringmap.StringMap{}
+
+	result["responseBodyBytes"] = strconv.FormatUint(response.ResponseBodyBytes, 10)
+	result["responseCodeDetails"] = response.ResponseCodeDetails
+	result["responseCode"] = strconv.FormatUint(uint64(response.ResponseCode.GetValue()), 10)
+	result["responseHeadersBytes"] = strconv.FormatUint(response.ResponseHeadersBytes, 10)
+	// response headers are encoded with `sent_http_` prefix (to keep the scheme used by Nginx)
+	if response.ResponseHeaders != nil {
+		for header_name, header_value := range response.ResponseHeaders {
+			result["sent_http_"+header_name] = header_value
+		}
+	}
+	if response.ResponseTrailers != nil {
+		for trailer_name, trailer_value := range response.ResponseTrailers {
+			result["sent_trailer_"+trailer_name] = trailer_value
+		}
+	}
+	return result
+}
+
+type envoyV3HttpAccessLogEntry envoy_data_accesslog_v3.HTTPAccessLogEntry
+
+func (l envoyV3HttpAccessLogEntry) StringMap(logger logrus.FieldLogger) stringmap.StringMap {
+	m := envoyV3AccessLogEntryCommonProperties(*l.CommonProperties).StringMap(logger)
+	m["protocolVersion"] = l.ProtocolVersion.String()
+	m = m.Merge(envoyV3AccessLogEntryHttpRequestProperties(*l.Request).StringMap(logger))
+	m = m.Merge(envoyV3AccessLogEntryHttpResponseProperties(*l.Response).StringMap(logger))
+	return m
+}
+
+type envoyV3TcpAccessLogEntry envoy_data_accesslog_v3.TCPAccessLogEntry
+
+func (l envoyV3TcpAccessLogEntry) StringMap(logger logrus.FieldLogger) stringmap.StringMap {
+	m := envoyV3AccessLogEntryCommonProperties(*l.CommonProperties).StringMap(logger)
+	m["receivedBytes"] = strconv.FormatUint(l.ConnectionProperties.ReceivedBytes, 10)
+	m["sentBytes"] = strconv.FormatUint(l.ConnectionProperties.SentBytes, 10)
+	return m
+}
+
+func (service_v3 *AccessLogServiceV3) emitEvents(msg *envoy_service_accesslog_v3.StreamAccessLogsMessage) {
+	if logs := msg.GetHttpLogs(); logs != nil {
+		for _, l := range logs.LogEntry {
+			logEntriesTotal.WithLabelValues("HTTP", "v3").Inc()
+			e := &event.Raw{
+				Metadata: envoyV3HttpAccessLogEntry(*l).StringMap(service_v3.logger),
+				Quantity: 1,
+			}
+			service_v3.logger.Debug(e)
+			service_v3.outChan <- e
+		}
+	} else if logs := msg.GetTcpLogs(); logs != nil {
+		for _, l := range logs.LogEntry {
+			logEntriesTotal.WithLabelValues("TCP", "v3").Inc()
+			e := &event.Raw{
+				Metadata: envoyV3TcpAccessLogEntry(*l).StringMap(service_v3.logger),
+				Quantity: 1,
+			}
+			service_v3.logger.Debug(e)
+			service_v3.outChan <- e
+		}
+	} else {
+		// Unknown access log type
+		errorsTotal.WithLabelValues("UnknownLogType").Inc()
+		service_v3.logger.Warnf("Unknown access log message type: %v", msg)
+	}
+}
+
+func (service_v3 *AccessLogServiceV3) StreamAccessLogs(stream envoy_service_accesslog_v3.AccessLogService_StreamAccessLogsServer) error {
+	for {
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			errorsTotal.WithLabelValues("ProcessingStream").Inc()
+			return err
+		}
+		service_v3.emitEvents(msg)
+	}
+	return nil
+}
+
+func (service_v3 *AccessLogServiceV3) Register(server *grpc.Server) {
+	envoy_service_accesslog_v3.RegisterAccessLogServiceServer(server, service_v3)
+}

--- a/pkg/envoy_access_log_server/service_v3_test.go
+++ b/pkg/envoy_access_log_server/service_v3_test.go
@@ -1,0 +1,330 @@
+package envoy_access_log_server
+
+import (
+	"testing"
+
+	v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_data_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v3"
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/seznam/slo-exporter/pkg/stringmap"
+)
+
+var (
+	logger = &logrus.Logger{}
+)
+
+func Test_exportCommonPropertiesV3(t *testing.T) {
+	tests := []struct {
+		description    string
+		input          envoy_data_accesslog_v3.AccessLogCommon
+		expectedResult stringmap.StringMap
+	}{
+		{
+			description: "Empty AccessLogCommon properties",
+			input:       envoy_data_accesslog_v3.AccessLogCommon{},
+			expectedResult: stringmap.StringMap{
+				"sampleRate": "0",
+			},
+		},
+		{
+			description: "Non-empty AccessLogCommon properties",
+			input: envoy_data_accesslog_v3.AccessLogCommon{
+				SampleRate: 1,
+				DownstreamDirectRemoteAddress: &v3.Address{Address: &v3.Address_SocketAddress{SocketAddress: &v3.SocketAddress{
+					Address:       "127.0.0.1",
+					PortSpecifier: &v3.SocketAddress_PortValue{44848},
+				}}},
+				DownstreamRemoteAddress: &v3.Address{Address: &v3.Address_SocketAddress{SocketAddress: &v3.SocketAddress{
+					Address:       "127.0.0.1",
+					PortSpecifier: &v3.SocketAddress_PortValue{46058},
+				}}},
+				DownstreamLocalAddress: &v3.Address{Address: &v3.Address_SocketAddress{SocketAddress: &v3.SocketAddress{
+					Address:       "127.0.0.1",
+					PortSpecifier: &v3.SocketAddress_PortValue{8080},
+				}}},
+				TlsProperties: &envoy_data_accesslog_v3.TLSProperties{
+					TlsVersion:     4, // TLSv1_3
+					TlsCipherSuite: &wrappers.UInt32Value{Value: 4865},
+				},
+				StartTime: &timestamp.Timestamp{
+					Seconds: 1608647248,
+					Nanos:   741408000,
+				},
+				TimeToLastRxByte: &duration.Duration{
+					Nanos: 101859,
+				},
+				TimeToFirstUpstreamTxByte: &duration.Duration{
+					Nanos: 490187312,
+				},
+				TimeToLastUpstreamTxByte: &duration.Duration{
+					Nanos: 490187312,
+				},
+				TimeToFirstUpstreamRxByte: &duration.Duration{
+					Nanos: 463920708,
+				},
+				TimeToLastUpstreamRxByte: &duration.Duration{
+					Nanos: 490187312,
+				},
+				TimeToFirstDownstreamTxByte: &duration.Duration{
+					Nanos: 490791797,
+				},
+				TimeToLastDownstreamTxByte: &duration.Duration{
+					Nanos: 490791800,
+				},
+				UpstreamRemoteAddress: &v3.Address{Address: &v3.Address_SocketAddress{SocketAddress: &v3.SocketAddress{
+					Address:       "77.75.75.172",
+					PortSpecifier: &v3.SocketAddress_PortValue{443},
+				}}},
+				UpstreamLocalAddress: &v3.Address{Address: &v3.Address_SocketAddress{SocketAddress: &v3.SocketAddress{
+					Address:       "10.0.116.130",
+					PortSpecifier: &v3.SocketAddress_PortValue{48734},
+				}}},
+				UpstreamCluster: "service_seznam_cz",
+				ResponseFlags: &envoy_data_accesslog_v3.ResponseFlags{
+					ResponseFromCacheFilter: true,
+				},
+				Metadata:                       nil,
+				UpstreamTransportFailureReason: "foo",
+				RouteName:                      "foo",
+
+				FilterStateObjects: nil,
+			},
+			expectedResult: stringmap.StringMap{
+				"downstreamDirectRemoteAddress":  "127.0.0.1",
+				"downstreamDirectRemotePort":     "44848",
+				"downstreamLocalAddress":         "127.0.0.1",
+				"downstreamLocalPort":            "8080",
+				"downstreamRemoteAddress":        "127.0.0.1",
+				"downstreamRemotePort":           "46058",
+				"routeName":                      "foo",
+				"sampleRate":                     "1",
+				"startTime":                      "2020-12-22T14:27:28Z",
+				"timeToFirstDownstreamTxByte":    "490791797ns",
+				"timeToFirstUpstreamRxByte":      "463920708ns",
+				"timeToFirstUpstreamTxByte":      "490187312ns",
+				"timeToLastDownstreamTxByte":     "490791800ns",
+				"timeToLastRxByte":               "101859ns",
+				"timeToLastUpstreamRxByte":       "490187312ns",
+				"timeToLastUpstreamTxByte":       "490187312ns",
+				"upstreamCluster":                "service_seznam_cz",
+				"upstreamLocalAddress":           "10.0.116.130",
+				"upstreamLocalPort":              "48734",
+				"upstreamRemoteAddress":          "77.75.75.172",
+				"upstreamRemotePort":             "443",
+				"upstreamTransportFailureReason": "foo",
+			},
+		},
+	}
+	for _, tt := range tests {
+		f := func(*testing.T) {
+			output := envoyV3AccessLogEntryCommonProperties(tt.input).StringMap(logger)
+			for k, v := range tt.expectedResult {
+				assert.Equal(t, v, output[k], "expected %s=%s", k, v)
+			}
+		}
+		t.Run(tt.description, f)
+	}
+}
+
+func Test_exportHTTPRequestPropertiesV3(t *testing.T) {
+	tests := []struct {
+		description    string
+		input          envoy_data_accesslog_v3.HTTPRequestProperties
+		expectedResult stringmap.StringMap
+	}{
+		{
+			description: "Empty request properties",
+			input:       envoy_data_accesslog_v3.HTTPRequestProperties{},
+			expectedResult: stringmap.StringMap{
+				"requestMethod":       "METHOD_UNSPECIFIED",
+				"requestHeadersBytes": "0",
+				"requestBodyBytes":    "0",
+			},
+		},
+		{
+			description: "Non-empty request properties",
+			input: envoy_data_accesslog_v3.HTTPRequestProperties{
+				RequestMethod:       1, // GET
+				Scheme:              "https",
+				Authority:           "www.seznam.cz",
+				Path:                "/",
+				UserAgent:           "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:83.0) Gecko/20100101 Firefox/83.0",
+				Referer:             "xxx",
+				ForwardedFor:        "xxx",
+				RequestId:           "f1d027b9-8b7f-448a-bbe2-1a3151801af1",
+				OriginalPath:        "",
+				RequestHeadersBytes: 932,
+				RequestBodyBytes:    0,
+				RequestHeaders:      map[string]string{"foo": "bar"},
+			},
+			expectedResult: stringmap.StringMap{
+				"requestMethod":       "GET",
+				"scheme":              "https",
+				"authority":           "www.seznam.cz",
+				"path":                "/",
+				"userAgent":           "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:83.0) Gecko/20100101 Firefox/83.0",
+				"referer":             "xxx",
+				"forwardedFor":        "xxx",
+				"requestId":           "f1d027b9-8b7f-448a-bbe2-1a3151801af1",
+				"requestHeadersBytes": "932",
+				"requestBodyBytes":    "0",
+				"http_foo":            "bar",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		f := func(*testing.T) {
+			for k, v := range test.expectedResult {
+				assert.Equal(t, v, envoyV3AccessLogEntryHttpRequestProperties(test.input).StringMap(logger)[k], "expected %s=%s", k, v)
+			}
+		}
+		t.Run(test.description, f)
+	}
+}
+
+func Test_exportHTTPResponsePropertiesV3(t *testing.T) {
+	tests := []struct {
+		description string
+		input       envoy_data_accesslog_v3.HTTPResponseProperties
+		result      stringmap.StringMap
+	}{
+		{
+			description: "Empty response properties",
+			input:       envoy_data_accesslog_v3.HTTPResponseProperties{},
+			result: stringmap.StringMap{
+				"responseCode":         "0",
+				"responseHeadersBytes": "0",
+				"responseBodyBytes":    "0",
+				"responseCodeDetails":  "",
+			}},
+		{
+			description: "Non-empty response properties",
+			input: envoy_data_accesslog_v3.HTTPResponseProperties{
+				ResponseCode:         &wrappers.UInt32Value{Value: 200},
+				ResponseHeadersBytes: 166,
+				ResponseBodyBytes:    74400,
+				ResponseHeaders:      map[string]string{"slo-domain": "userportal", "slo-class": "critical"},
+				ResponseTrailers:     map[string]string{"slo-availability-expectedResult": "success"},
+				ResponseCodeDetails:  "via_upstream",
+			},
+			result: stringmap.StringMap{
+				"responseCode":                                 "200",
+				"responseHeadersBytes":                         "166",
+				"responseBodyBytes":                            "74400",
+				"sent_http_slo-class":                          "critical",
+				"sent_http_slo-domain":                         "userportal",
+				"sent_trailer_slo-availability-expectedResult": "success",
+				"responseCodeDetails":                          "via_upstream",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		f := func(*testing.T) {
+			assert.Equal(t, test.result, envoyV3AccessLogEntryHttpResponseProperties(test.input).StringMap(logger))
+		}
+		t.Run(test.description, f)
+	}
+}
+
+// Make sure that all HTTP log entry properties are extracted. Just a minimal test case is present,
+// full extent extraction of request, response and common properties are to be tested separately within:
+// Test_exportHTTPResponsePropertiesV3
+// Test_exportHTTPRequestPropertiesV3
+// Test_exportCommonPropertiesV3
+func Test_exportHttpLogEntryV3(t *testing.T) {
+	tests := []struct {
+		description    string
+		expectedOutput stringmap.StringMap
+		logEntry       *envoy_data_accesslog_v3.HTTPAccessLogEntry
+	}{
+		{
+			description: "Minimal HTTP log entry",
+			logEntry: &envoy_data_accesslog_v3.HTTPAccessLogEntry{
+				CommonProperties: &envoy_data_accesslog_v3.AccessLogCommon{
+					SampleRate: 1,
+					UpstreamRemoteAddress: &v3.Address{Address: &v3.Address_SocketAddress{SocketAddress: &v3.SocketAddress{
+						Address:       "77.75.75.172",
+						PortSpecifier: &v3.SocketAddress_PortValue{443},
+					}}},
+				},
+				ProtocolVersion: 2,
+				Request: &envoy_data_accesslog_v3.HTTPRequestProperties{
+					Scheme:    "http",
+					Authority: "www.seznam.cz",
+					Path:      "/",
+				},
+				Response: &envoy_data_accesslog_v3.HTTPResponseProperties{
+					ResponseCode: &wrappers.UInt32Value{Value: 200},
+				},
+			},
+			expectedOutput: stringmap.StringMap{
+				"authority":             "www.seznam.cz",
+				"path":                  "/",
+				"protocolVersion":       "HTTP11",
+				"responseCode":          "200",
+				"sampleRate":            "1",
+				"scheme":                "http",
+				"upstreamRemoteAddress": "77.75.75.172",
+				"upstreamRemotePort":    "443",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		f := func(*testing.T) {
+			output := envoyV3HttpAccessLogEntry(*test.logEntry).StringMap(logger)
+			for k, v := range test.expectedOutput {
+				assert.Equal(t, v, output[k], "expected %s=%s", k, v)
+			}
+		}
+		t.Run(test.description, f)
+	}
+}
+
+func Test_exportTcpLogEntryV3(t *testing.T) {
+	tests := []struct {
+		description    string
+		expectedOutput stringmap.StringMap
+		logEntry       *envoy_data_accesslog_v3.TCPAccessLogEntry
+	}{
+		{
+			description: "Full TCP log entry",
+			logEntry: &envoy_data_accesslog_v3.TCPAccessLogEntry{
+				CommonProperties: &envoy_data_accesslog_v3.AccessLogCommon{
+					SampleRate: 1,
+					UpstreamRemoteAddress: &v3.Address{Address: &v3.Address_SocketAddress{SocketAddress: &v3.SocketAddress{
+						Address:       "77.75.75.172",
+						PortSpecifier: &v3.SocketAddress_PortValue{443},
+					}}},
+				},
+				ConnectionProperties: &envoy_data_accesslog_v3.ConnectionProperties{
+					ReceivedBytes: uint64(100),
+					SentBytes:     uint64(100),
+				},
+			},
+			expectedOutput: stringmap.StringMap{
+				"receivedBytes":         "100",
+				"sampleRate":            "1",
+				"sentBytes":             "100",
+				"upstreamCluster":       "",
+				"upstreamRemoteAddress": "77.75.75.172",
+				"upstreamRemotePort":    "443",
+			}},
+	}
+
+	for _, test := range tests {
+		f := func(*testing.T) {
+			for k, v := range test.expectedOutput {
+				assert.Equal(t, v, envoyV3TcpAccessLogEntry(*test.logEntry).StringMap(logger)[k], "expected %s=%s", k, v)
+			}
+		}
+		t.Run(test.description, f)
+	}
+}

--- a/pkg/envoy_access_log_server/util.go
+++ b/pkg/envoy_access_log_server/util.go
@@ -1,0 +1,20 @@
+package envoy_access_log_server
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/ptypes"
+	pbduration "github.com/golang/protobuf/ptypes/duration"
+)
+
+// Returns deterministic string representation of 'pbduration' - ns
+func pbDurationDeterministicString(pbduration *pbduration.Duration) (string, error) {
+	if pbduration == nil {
+		return "", fmt.Errorf("<nil> duration given")
+	}
+	duration, err := ptypes.Duration(pbduration)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprint(duration.Nanoseconds()) + "ns", nil
+}

--- a/pkg/pipeline/module.go
+++ b/pkg/pipeline/module.go
@@ -3,9 +3,9 @@ package pipeline
 import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/seznam/slo-exporter/pkg/event"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"github.com/seznam/slo-exporter/pkg/event"
 )
 
 type moduleFactoryFunction func(moduleName string, logger logrus.FieldLogger, conf *viper.Viper) (Module, error)

--- a/pkg/prometheus_exporter/prometheus_exporter_test.go
+++ b/pkg/prometheus_exporter/prometheus_exporter_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/seznam/slo-exporter/pkg/event"
 	"github.com/seznam/slo-exporter/pkg/stringmap"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 )

--- a/pkg/stringmap/stringmap.go
+++ b/pkg/stringmap/stringmap.go
@@ -1,10 +1,11 @@
 package stringmap
 
 import (
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/pkg/labels"
 	"sort"
 	"strings"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
 )
 
 func NewFromMetric(labels model.Metric) StringMap {
@@ -178,4 +179,3 @@ func (m StringMap) AsPrometheusLabels() labels.Labels {
 	}
 	return newLabels
 }
-


### PR DESCRIPTION
~~Both currently supported APIs are covered, [v2](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api), [v3](https://www.envoyproxy.io/docs/envoy/latest/api-v3/api). (Suggestions on how to avoid this awful code duplicity are welcomed :) )~~ Just support for the current stable version (v3) has been added.

What remains to be done within this PR:
- [x] finish tests
- [x] make string representation of Duration deterministic so that slo_event_producer won't break randomly
~~- [ ] consider adding raw protobuf JSON serialization to the generated event's metadata~~
- [x] documentation :|

All-in-one example demonstrating usage will be added within a separate PR. 