### PR TITLE
doc: added envoy_proxy example

### DIFF
--- a/examples/envoy_proxy/README.md
+++ b/examples/envoy_proxy/README.md
@@ -1,0 +1,27 @@
+# Envoy proxy SLO example
+
+This example shows a simple configuration of slo-exporter using
+[`envoy access-log-server module`](/docs/modules/envoy_access_log_server.md).
+
+#### How to run it
+In root of the repo
+```bash
+make docker
+cd examples/envoy_proxy
+docker-compose up -d
+```
+Once started, see http://localhost:8001/metrics.
+
+## How SLO is computed
+- [envoyAccessLogServer module](/docs/modules/envoy_access_log_server.md) is used to receive envoy's logs via grpc.
+- [relabel module](/docs/modules/relabel.md) drops the unwanted events (e.g. based on its HTTP status code, userAgent,...).
+- [dynamicClassifier module](/docs/modules/dynamicClassifier.md) classifies generated event based on provided [classification.csv](./classification.csv)
+
+## Observed SLO types
+Refer to [slo_rules.yaml](./slo_rules.yaml) for the exact configuration of how SLO events are generated based on input logs/events.
+
+#### `availability`
+For every log line which results in classified event in domain `test-domain`, an SLO event is generated. Its result is determined based on statusCode metadata key - with all events with `statusCode > 500` being marked as failed.
+
+#### `latency90`, `latency99`
+For every log line which results in classified event in domain `test-domain` and slo_class `critical`, an SLO event is generated. Its result is determined based on `timeToLastDownstreamTxByte` metadata key.

--- a/examples/envoy_proxy/docker-compose.yaml
+++ b/examples/envoy_proxy/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: '3'
+
+services:
+  envoy:
+    network_mode: "host"
+    image: envoyproxy/envoy:v1.16-latest
+    volumes:
+      - "./envoy/envoy.yaml:/conf/envoy.yaml:ro"
+    command:
+      - "-c"
+      - "/conf/envoy.yaml"
+
+  slo-exporter:
+    network_mode: "host"
+    image: slo_exporter:latest
+    ports:
+      - 8001:8001
+    working_dir: /slo-exporter
+    command:
+      - "--config-file=/slo-exporter/slo_exporter.yaml"
+      - "--log-level=debug"
+    volumes:
+      - ./slo-exporter/:/slo-exporter/
+
+  slo-event-generator:
+    network_mode: "host"
+    image: curlimages/curl
+    entrypoint: /bin/sh
+    command: |
+        -c 'while true; do
+                  for i in `seq 20`; do curl -s -H "slo-domain: example-domain" -H "slo-class: critical" -H "slo-app: homepage-static" http://localhost:8080/ >/dev/null 2>&1 ; done;
+                  echo -n ".";
+                  sleep 5;
+                done'

--- a/examples/envoy_proxy/envoy/envoy.yaml
+++ b/examples/envoy_proxy/envoy/envoy.yaml
@@ -1,0 +1,73 @@
+static_resources:
+
+  listeners:
+  - name: listener_0
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8080
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: /dev/stdout
+          - name: envoy.access_loggers.http_grpc
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig
+              common_config:
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: service_accesslog
+                buffer_size_bytes:
+                  value: 0
+                log_name: accesslogv3
+                transport_api_version: V3
+              additional_request_headers_to_log: ['slo-class', 'slo-domain', 'slo-app']
+          http_filters:
+          - name: envoy.filters.http.router
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: service_neverssl_com
+                  host_rewrite_literal: neverssl.com
+
+  clusters:
+  - name: service_accesslog
+    connect_timeout: 6s
+    type: LOGICAL_DNS
+    load_assignment:
+      cluster_name: service_accesslog
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: localhost
+                port_value: 18090
+    http2_protocol_options: {}
+
+  - name: service_neverssl_com
+    connect_timeout: 30s
+    type: LOGICAL_DNS
+    dns_lookup_family: V4_ONLY
+    load_assignment:
+      cluster_name: service_neverssl_com
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: neverssl.com
+                port_value: 80

--- a/examples/envoy_proxy/slo-exporter/slo_exporter.yaml
+++ b/examples/envoy_proxy/slo-exporter/slo_exporter.yaml
@@ -1,0 +1,40 @@
+webServerListenAddress: "0.0.0.0:8001"
+maximumGracefulShutdownDuration: "10s"
+afterPipelineShutdownDelay: "1s"
+
+pipeline: ["envoyAccessLogServer", "relabel", "eventKeyGenerator", "metadataClassifier", "sloEventProducer", "prometheusExporter"]
+
+modules:
+
+  envoyAccessLogServer: {}
+
+  relabel:
+    eventRelabelConfigs:
+      # Drop events with unwanted status codes
+    - source_labels: ["responseCode"]
+      regex: "30[12]|40[045]|411|408|499"
+      action: drop
+
+  eventKeyGenerator:
+    filedSeparator: ":"
+    metadataKeys:
+      - requestMethod
+      - path
+
+  metadataClassifier:
+    sloDomainMetadataKey: http_slo-domain
+    sloClassMetadataKey: http_slo-class
+    sloAppMetadataKey: http_slo-app
+
+  sloEventProducer:
+    rulesFiles:
+      - "slo_rules.yaml"
+
+  prometheusExporter:
+    metricName: "slo_events_total"
+    labelNames:
+      result: "result"
+      sloDomain: "slo_domain"
+      sloClass: "slo_class"
+      sloApp: "slo_app"
+      eventKey: "event_key"

--- a/examples/envoy_proxy/slo-exporter/slo_rules.yaml
+++ b/examples/envoy_proxy/slo-exporter/slo_rules.yaml
@@ -1,0 +1,39 @@
+rules:
+  - slo_matcher:
+      domain: example-domain
+    failure_conditions:
+      - operator: numberIsEqualOrHigherThan
+        key: responseCode
+        value: 500
+    additional_metadata:
+      slo_type: availability
+      slo_version: 1
+      namespace: test
+
+  - slo_matcher:
+      domain: example-domain
+      class: critical
+    failure_conditions:
+      - operator: durationIsHigherThan
+        key: timeToLastDownstreamTxByte
+        value: 10ms
+    additional_metadata:
+      slo_version: 1
+      slo_type: latency90
+      percentile: 90
+      le: 0.01
+      namespace: test
+
+  - slo_matcher:
+      domain: example-domain
+      class: critical
+    failure_conditions:
+      - operator: durationIsHigherThan
+        key: timeToLastDownstreamTxByte
+        value: 50ms
+    additional_metadata:
+      slo_version: 1
+      slo_type: latency99
+      percentile: 99
+      le: 0.05
+      namespace: test


### PR DESCRIPTION
This is built on top of https://github.com/seznam/slo-exporter/pull/37.

While I originally intended to add a separate all_in_one example (or add envoy to the existing all_in_one example), I eventually decided to create just a simple example with just envoy, slo-exporter and traffic generator. This is enough to demonstrate how the new module can be used and configured.

All-in-one example serves rather different purpose - demonstrate the whole SLO computation and visualization, event source does not matter much there, so I'm leaving it with the tailer module for now. 