### PR TITLE
fix prometheus-exporter: additional metadata of SLO event overrides o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+- [#39](https://github.com/seznam/slo-exporter/pull/39) Prometheus-exporter: Additional SLO event metadata does not get overwritten.
+
 ## Changed
 - [#40](https://github.com/seznam/slo-exporter/pull/40) Upgrade to Go 1.15
 

--- a/pkg/prometheus_exporter/prometheus_exporter.go
+++ b/pkg/prometheus_exporter/prometheus_exporter.go
@@ -209,13 +209,13 @@ func (e *PrometheusSloEventExporter) initializeMetricForGivenMetadata(metadata s
 }
 
 func (e *PrometheusSloEventExporter) labelsFromEvent(sloEvent *event.Slo) stringmap.StringMap {
-	return sloEvent.Metadata.Merge(stringmap.StringMap{
+	return stringmap.StringMap{
 		e.labelNames.Result:    string(sloEvent.Result),
 		e.labelNames.SloDomain: sloEvent.Domain,
 		e.labelNames.SloClass:  sloEvent.Class,
 		e.labelNames.SloApp:    sloEvent.App,
 		e.labelNames.EventKey:  sloEvent.Key,
-	})
+	}.Merge(sloEvent.Metadata)
 }
 
 func (e *PrometheusSloEventExporter) processEvent(newEvent *event.Slo) error {


### PR DESCRIPTION
Currently, additional metadata of an SLO event does get overwritten by other metadata of the event.
This should fix it.