### PR TITLE
fix: goreleaser after dropped support for darwin/386 arch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,10 @@ builds:
       - amd64
       - 386
 
+    ignore:
+    - goos: darwin
+      goarch: 386
+
 source:
   enabled: true
 


### PR DESCRIPTION
https://golang.org/doc/go1.15