### PR TITLE
feat slo-event-producer: change slo_matcher from string to regexp matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- [#43](https://github.com/seznam/slo-exporter/pull/40) slo-event-producer: `slo_matcher` values are now regular expressions.
 
 ## [v6.6.0] 2021-01-19
 ## Added

--- a/docs/modules/slo_event_producer.md
+++ b/docs/modules/slo_event_producer.md
@@ -38,9 +38,9 @@ metadata_matcher:
   - <metadata_matcher_condition>
 # Matcher of the SLO classification of the event. Rule will be applied only if matches the event SLO classification.
 slo_matcher:
-  domain: <value>
-  class: <value>
-  app: <value>
+  domain: <regexp>
+  class: <regexp>
+  app: <regexp>
 # Conditions to be checked on the matching event, if any of those results with true, the event is marked as failure, otherwise success.
 failure_conditions:
   - <failure_condition>

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hpcloud/tail v1.0.1-0.20180514194441-a1dbeea552b7
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.6.0
 	github.com/prometheus/common v0.10.0
 	github.com/prometheus/prometheus v1.8.2-0.20200213233353-b90be6f32a33
@@ -25,7 +24,6 @@ require (
 	golang.org/x/tools v0.0.0-20200828161849-5deb26317202 // indirect
 	gonum.org/v1/gonum v0.7.0
 	google.golang.org/grpc v1.27.0
-	google.golang.org/protobuf v1.23.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/pkg/slo_event_producer/config.go
+++ b/pkg/slo_event_producer/config.go
@@ -11,9 +11,9 @@ import (
 )
 
 type sloMatcher struct {
-	Domain string `yaml:"domain"`
-	Class  string `yaml:"class"`
-	App    string `yaml:"app"`
+	DomainRegexp string `yaml:"domain"`
+	ClassRegexp  string `yaml:"class"`
+	AppRegexp    string `yaml:"app"`
 }
 
 type operatorOptions struct {

--- a/pkg/slo_event_producer/config_test.go
+++ b/pkg/slo_event_producer/config_test.go
@@ -23,7 +23,7 @@ func TestConfig_loadFromFile(t *testing.T) {
 			path: "testdata/slo_rules_valid.yaml.golden",
 			expectedConfig: rulesConfig{Rules: []ruleOptions{
 				{
-					SloMatcher: sloMatcher{Domain: "domain"},
+					SloMatcher: sloMatcher{DomainRegexp: "domain"},
 					FailureConditionsOptions: []operatorOptions{
 						operatorOptions{
 							Operator: "numberIsHigherThan", Key: "statusCode", Value: "500",

--- a/pkg/slo_event_producer/event_evaluator_test.go
+++ b/pkg/slo_event_producer/event_evaluator_test.go
@@ -24,7 +24,7 @@ func TestSloEventProducer(t *testing.T) {
 			inputEvent: event.Raw{Metadata: stringmap.StringMap{"statusCode": "502"}, SloClassification: &event.SloClassification{Class: "class", App: "app", Domain: "domain"}},
 			rulesConfig: rulesConfig{Rules: []ruleOptions{
 				{
-					SloMatcher:                       sloMatcher{Domain: "domain"},
+					SloMatcher:                       sloMatcher{DomainRegexp: "domain"},
 					MetadataMatcherConditionsOptions: []operatorOptions{},
 					FailureConditionsOptions: []operatorOptions{
 						operatorOptions{
@@ -43,7 +43,7 @@ func TestSloEventProducer(t *testing.T) {
 			inputEvent: event.Raw{Metadata: stringmap.StringMap{"statusCode": "200"}, SloClassification: &event.SloClassification{Class: "class", App: "app", Domain: "domain"}},
 			rulesConfig: rulesConfig{Rules: []ruleOptions{
 				{
-					SloMatcher:                       sloMatcher{Domain: "domain"},
+					SloMatcher:                       sloMatcher{DomainRegexp: "domain"},
 					MetadataMatcherConditionsOptions: []operatorOptions{},
 					FailureConditionsOptions: []operatorOptions{
 						operatorOptions{

--- a/pkg/slo_event_producer/rule_test.go
+++ b/pkg/slo_event_producer/rule_test.go
@@ -4,10 +4,10 @@ package slo_event_producer
 //revive:enable:var-naming
 
 import (
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/seznam/slo-exporter/pkg/event"
 	"github.com/seznam/slo-exporter/pkg/stringmap"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"regexp"
 	"testing"
 )
@@ -67,7 +67,7 @@ func TestEvaluateEvent(t *testing.T) {
 		{
 			name: "event does not match the only matcher -> error reported",
 			rule: evaluationRule{
-				sloMatcher:         event.SloClassification{Domain: "foo"},
+				sloMatcher:         sloClassificationMatcher{domainRegexp: regexp.MustCompile("foo")},
 				additionalMetadata: stringmap.StringMap{},
 				failureConditions:  []operator{&isMatchingRegexp{key: "statusCode", regexp: regexp.MustCompile("500")}},
 				logger:             logrus.New(),
@@ -82,7 +82,7 @@ func TestEvaluateEvent(t *testing.T) {
 		{
 			name: "event does not match any matcher -> error reported",
 			rule: evaluationRule{
-				sloMatcher:         event.SloClassification{Domain: "domain"},
+				sloMatcher:         sloClassificationMatcher{domainRegexp: regexp.MustCompile("domain")},
 				metadataMatcher:    []operator{&isMatchingRegexp{key: "key", regexp: regexp.MustCompile("value")}},
 				additionalMetadata: stringmap.StringMap{},
 				failureConditions:  []operator{&isMatchingRegexp{key: "statusCode", regexp: regexp.MustCompile("500")}},
@@ -98,7 +98,7 @@ func TestEvaluateEvent(t *testing.T) {
 		{
 			name: "metadata matcher matches, failure_condition does not match -> succesful event",
 			rule: evaluationRule{
-				sloMatcher:         event.SloClassification{Domain: "domain"},
+				sloMatcher:         sloClassificationMatcher{domainRegexp: regexp.MustCompile("domain")},
 				metadataMatcher:    []operator{&isMatchingRegexp{key: "key", regexp: regexp.MustCompile("value")}},
 				additionalMetadata: stringmap.StringMap{},
 				failureConditions:  []operator{&isMatchingRegexp{key: "statusCode", regexp: regexp.MustCompile("500")}},

--- a/test/Test_MetricsInitialization/slo_rules.yaml
+++ b/test/Test_MetricsInitialization/slo_rules.yaml
@@ -1,6 +1,6 @@
 rules:
   - slo_matcher:
-      domain: testdomain
+      domain: testdo.*
     failure_conditions:
       - operator: numberIsHigherThan
         key: statusCode


### PR DESCRIPTION
To be more flexible, allow regexp matching of the SLO value in the slo-event-producer rules config

