### PR TITLE
Install ca-certificates to docker base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#44](https://github.com/seznam/slo-exporter/issues/44) Install missing ca-certificates to docker base image
 
 ## [v6.7.0] 2021-01-29
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:stable-slim
 
+RUN apt-get update && apt-get install ca-certificates -y && apt-get clean
+
 COPY slo_exporter  /slo_exporter/
 COPY Dockerfile /
 


### PR DESCRIPTION
### Identify the Bug

https://github.com/seznam/slo-exporter/issues/44

### Description of the Change

This change install ca-certificates to docker base image to fix the issue when prometheusIngester module queries prometheus installation that uses HTTPS