### PR TITLE
fix: offsetPersistenceTestRun CI job flakiness

### DIFF
--- a/pkg/tailer/tailer_test.go
+++ b/pkg/tailer/tailer_test.go
@@ -2,8 +2,8 @@ package tailer
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"github.com/seznam/slo-exporter/pkg/event"
+	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -319,7 +319,7 @@ func offsetPersistenceTestRun(t offsetPersistenceTest) error {
 	for i := 0; i < t.during; i++ {
 		f.WriteString(getRequestLine(requestLineFormatMapValid) + "\n")
 	}
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(time.Second)
 
 	tailer.Stop()
 	eventsCount := <-eventCount
@@ -343,7 +343,7 @@ func offsetPersistenceTestRun(t offsetPersistenceTest) error {
 		f.WriteString(getRequestLine(requestLineFormatMapValid) + "\n")
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(time.Second)
 
 	tailer.Stop()
 	eventsCount = <-eventCount


### PR DESCRIPTION
`offsetPersistenceTestRun` is quite flaky in the CI pipeline (opposed to when it is run locally). I assume this is a problem related to somewhat shared environment in which CI jobs are run, let's hope that the timeout increase should be enough to mitigate this.