### PR TITLE
feat: sync recording rules and alerts

### DIFF
--- a/prometheus/alerts/error-budget.yaml
+++ b/prometheus/alerts/error-budget.yaml
@@ -5,7 +5,7 @@ groups:
   - alert: ErrorBudgetExhausted
     expr:
             slo:stable_version{enabled!="false"}
-            * on(slo_version, slo_domain, namespace) group_right(team)
+            * on(slo_version, slo_domain, namespace) group_right(escalate, team)
             slo:violation_ratio{slo_time_range="4w"}
             / on (slo_class,slo_domain,slo_version,slo_type,namespace) group_left ()
             (
@@ -15,7 +15,6 @@ groups:
     for: 10m
     labels:
       severity: warning
-      sre: true
       alert_type: slo:error_budget_exhausted
     annotations:
       title: 'Error budget is exhausted.'

--- a/prometheus/alerts/missing_all_data.yaml
+++ b/prometheus/alerts/missing_all_data.yaml
@@ -9,15 +9,14 @@ groups:
     expr: |
       (1 - avg_over_time(
           (clamp_max(sum(absent(slo:events_over_time
-          * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}))
+          * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}))
           AND sum(increase(prometheus_rule_evaluation_failures_total[5m]) > 0),0)
           OR clamp_max(sum(slo:events_over_time
-          * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}),1))[1h:])
+          * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}),1))[1h:])
       ) == 1
     for: 10m
     labels:
       severity: warning
-      sre: true
       alert_type: slo:missing_data
     annotations:
       title: 'Missing SLO data.'

--- a/prometheus/alerts/missing_data.yaml
+++ b/prometheus/alerts/missing_data.yaml
@@ -8,11 +8,11 @@ groups:
         (
           sum(
             slo:stable_version{enabled="true"}
-          ) by (slo_version, slo_domain, namespace, team)
+          ) by (slo_version, slo_domain, namespace, escalate, team)
           unless on (slo_domain, slo_version, namespace)
           (
             slo:burn_rate{slo_time_range='5m'}
-            * on(slo_version, slo_domain, namespace) group_left(team)
+            * on(slo_version, slo_domain, namespace) group_left(escalate, team)
             slo:stable_version{enabled="true"}
           )
         )
@@ -24,7 +24,6 @@ groups:
     labels:
       severity: critical
       alert_type: slo:missing_data
-      sre: true
     annotations:
       title: 'Missing burn rate data for {{ $labels.slo_domain }}.'
       description: 'Burn rate probably failed to evaluate for {{ $labels.slo_domain }}.'

--- a/prometheus/alerts/slo_burn_rate.yaml
+++ b/prometheus/alerts/slo_burn_rate.yaml
@@ -35,14 +35,14 @@ groups:
         (
           slo:burn_rate{slo_time_range="1h"}
           * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="1h", slo_domain!="userportal-exports"}
-          * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+          * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
           > 13.44
         )
         and on(percentile, slo_class, slo_domain, slo_type, slo_version, namespace)
         (
           slo:burn_rate{slo_time_range="5m"}
           * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="1h", slo_domain!="userportal-exports"}
-          * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+          * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
           > 13.44
         )
         and on(slo_class, slo_domain, slo_version, slo_type, namespace)
@@ -51,7 +51,6 @@ groups:
         )
       )
     labels:
-      sre: true
       severity: warning
       alert_type: slo:high_burnrate
     annotations:
@@ -68,14 +67,14 @@ groups:
     expr: (
         slo:burn_rate{slo_time_range="1h", slo_domain="userportal-exports"}
         * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="1h"}
-        * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+        * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
         > 20.16
       )
       and on(percentile, slo_class, slo_domain, slo_type, slo_version)
       (
         slo:burn_rate{slo_time_range="5m", slo_domain="userportal-exports"}
         * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="1h", slo_domain="userportal-exports"}
-        * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+        * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
         > 20.16
       )
       and on(slo_class, slo_domain, slo_version, slo_type, namespace)
@@ -84,7 +83,6 @@ groups:
       )
     labels:
       severity: critical
-      sre: true
       alert_type: slo:high_burnrate
     annotations:
       title: "High {{ $labels.slo_type }} burn-rate in SLO domain {{ $labels.slo_domain }} (last hour)"
@@ -100,14 +98,14 @@ groups:
     expr: (
         slo:burn_rate{slo_time_range="1h"}
         * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="1h", slo_domain!="userportal-exports"}
-        * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+        * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
         > 13.44
       )
       and on(percentile, slo_class, slo_domain, slo_type, slo_version, namespace)
       (
         slo:burn_rate{slo_time_range="5m"}
         * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="1h", slo_domain!="userportal-exports"}
-        * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+        * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
         > 13.44
       )
       and on(slo_class, slo_domain, slo_version, slo_type, namespace)
@@ -116,7 +114,6 @@ groups:
       )
     labels:
       severity: critical
-      sre: true
       alert_type: slo:high_burnrate
     annotations:
       title: "High {{ $labels.slo_type }} burn-rate in SLO domain {{ $labels.slo_domain }} (last hour)"
@@ -144,14 +141,14 @@ groups:
             (
               slo:burn_rate{slo_time_range="6h"}
               * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="6h"}
-              * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+              * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
               > 5.6
             )
             and on(percentile, slo_class, slo_domain, slo_type, slo_version, namespace)
             (
               slo:burn_rate{slo_time_range="30m"}
               * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="6h"}
-              * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+              * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
               > 5.6
             )
             and on(slo_class, slo_domain, slo_version, slo_type, namespace)
@@ -160,7 +157,6 @@ groups:
             )
         ) * on () group_left(severity) max(current_severity_level_info) by (severity)
     labels:
-      sre: true
       alert_type: slo:high_burnrate
     annotations:
       title: "High {{ $labels.slo_type }} burn-rate in SLO domain {{ $labels.slo_domain }} (6 hours, low traffic)"
@@ -176,14 +172,14 @@ groups:
       (
         slo:burn_rate{slo_time_range="6h"}
         * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="6h"}
-        * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+        * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
         > 5.6
       )
       and on(percentile, slo_class, slo_domain, slo_type, slo_version, namespace)
       (
         slo:burn_rate{slo_time_range="30m"}
         * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="6h"}
-        * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+        * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
         > 5.6
       )
       and on(slo_class, slo_domain, slo_version, slo_type, namespace)
@@ -192,7 +188,6 @@ groups:
       )
     labels:
       severity: critical
-      sre: true
       alert_type: slo:high_burnrate
     annotations:
       title: "High {{ $labels.slo_type }} burn-rate in SLO domain {{ $labels.slo_domain }} (6 hours)"
@@ -210,19 +205,18 @@ groups:
     expr: (
         slo:burn_rate{slo_time_range="1d"}
         * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="1d"}
-        * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+        * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
         > 2.8
       )
       and on(percentile, slo_class, slo_domain, slo_type, slo_version, namespace)
       (
         slo:burn_rate{slo_time_range="2h"}
         * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="1d"}
-        * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+        * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
         > 2.8
       )
     labels:
       severity: warning
-      sre: true
       alert_type: slo:high_burnrate
     annotations:
       title: "High {{ $labels.slo_type }} burn-rate in SLO domain {{ $labels.slo_domain }} (24 hours)"
@@ -242,19 +236,18 @@ groups:
       (
         slo:burn_rate{slo_time_range="3d"}
         * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="3d"}
-        * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+        * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
         > 1
       )
       and on(percentile, slo_class, slo_domain, slo_type, slo_version, namespace)
       (
         slo:burn_rate{slo_time_range="6h"}
         * on(slo_domain, slo_class, slo_version, slo_type, namespace) group_left() slo:events_rate_coefficient{slo_time_range="3d"}
-        * on(slo_version, slo_domain, namespace) group_left(team) slo:stable_version{enabled!="false"}
+        * on(slo_version, slo_domain, namespace) group_left(escalate, team) slo:stable_version{enabled!="false"}
         > 1
       )
     labels:
       severity: warning
-      sre: true
       alert_type: slo:high_burnrate
     annotations:
       title: "High {{ $labels.slo_type }} burn-rate in SLO domain {{ $labels.slo_domain }} (3 days)"

--- a/prometheus/alerts/slo_data_corrections.yaml
+++ b/prometheus/alerts/slo_data_corrections.yaml
@@ -9,7 +9,6 @@ groups:
         expr: 'avg_over_time(slo:correction_window[10m]) == 0'
         for: 10m
         labels:
-          sre: true
           severity: info
           team: sre
         annotations:

--- a/prometheus/recording_rules/burn-rate.yaml
+++ b/prometheus/recording_rules/burn-rate.yaml
@@ -2,21 +2,31 @@ groups:
 - name: slo-violation-ratio-and-burn-rate
   interval: 1m
   rules:
-    # Produce zero instead of NaN.
     - record: slo:violation_ratio
-      expr:
-        0 == sum(
-            slo:events_over_time
-        ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_time_range)
-          or on (slo_class, slo_domain, slo_version, slo_type, namespace, slo_time_range)
+      expr: |
         (
-          sum(
-              slo:events_over_time{result="fail"}
-          ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_time_range)
-          /
-          sum(
-              slo:events_over_time
-          ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_time_range)
+          # Produce zero instead of NaN.
+          0 == sum by(namespace, slo_class, slo_domain, slo_time_range, slo_type, slo_version) (
+            slo:events_over_time
+          )
+        )
+          or on(namespace, slo_class, slo_domain, slo_time_range, slo_type, slo_version)
+        # Otherwise, compute the actual violation ratio, if possible
+        (
+          sum by(namespace, slo_class, slo_domain, slo_time_range, slo_type, slo_version) (
+            slo:events_over_time{result="fail"}
+          )
+            /
+          sum by(namespace, slo_class, slo_domain, slo_time_range, slo_type, slo_version) (
+            slo:events_over_time
+          )
+        )
+          or on(namespace, slo_class, slo_domain, slo_time_range, slo_type, slo_version)
+        # Otherwise, if no failed events are present, return 0 violation_ratio for the given set of labels
+        (
+          0 * count by(namespace, slo_class, slo_domain, slo_time_range, slo_type, slo_version) (
+            slo:events_over_time
+          )
         )
     - record: slo:burn_rate
       expr:

--- a/prometheus/recording_rules/error-budget.yaml
+++ b/prometheus/recording_rules/error-budget.yaml
@@ -7,7 +7,7 @@ groups:
       expr: |
           slo:violation_ratio{slo_time_range="4w"}
             * on (slo_domain,slo_version, namespace) group_left() 
-          slo:stable_version
+          max(slo:stable_version) by (slo_class,slo_domain,slo_version, slo_type, namespace)
             / on (slo_class,slo_domain,slo_version, slo_type, namespace) group_left ()
           (slo:violation_ratio_threshold - 1)
             + 1

--- a/prometheus/recording_rules/events-over-time.yaml
+++ b/prometheus/recording_rules/events-over-time.yaml
@@ -1,5 +1,5 @@
 groups:
-- name: slo-events-over-time--interval-3m
+- name: slo-events-over-time-4w--interval-3m
   interval: 3m
   rules:
      - record: slo:events_over_time
@@ -9,6 +9,10 @@ groups:
             sum(
                 increase(slo_domain_slo_class:slo_events_total[4w])
             ) by (slo_class, slo_domain, slo_version, slo_type, result, namespace)
+            
+- name: slo-events-over-time-3d--interval-3m
+  interval: 3m
+  rules:
      - record: slo:events_over_time
        labels:
          slo_time_range: 3d
@@ -16,6 +20,10 @@ groups:
             sum(
                 increase(slo_domain_slo_class:slo_events_total[3d])
             ) by (slo_class, slo_domain, slo_version, slo_type, result, namespace)
+
+- name: slo-events-over-time-1d--interval-3m
+  interval: 3m
+  rules:
      - record: slo:events_over_time
        labels:
          slo_time_range: 1d
@@ -23,6 +31,10 @@ groups:
             sum(
                 increase(slo_domain_slo_class:slo_events_total[1d])
             ) by (slo_class, slo_domain, slo_version, slo_type, result, namespace)
+
+- name: slo-events-over-time-6h--interval-3m
+  interval: 3m
+  rules:
      - record: slo:events_over_time
        labels:
          slo_time_range: 6h
@@ -30,6 +42,10 @@ groups:
             sum(
                 increase(slo_domain_slo_class:slo_events_total[6h])
             ) by (slo_class, slo_domain, slo_version, slo_type, result, namespace)
+
+- name: slo-events-over-time-2h--interval-3m
+  interval: 3m
+  rules:
      - record: slo:events_over_time
        labels:
          slo_time_range: 2h

--- a/prometheus/recording_rules/metadata.yaml
+++ b/prometheus/recording_rules/metadata.yaml
@@ -14,6 +14,8 @@ groups:
           namespace: "test"
           slo_domain: example-domain
           enabled: true
+          team: "example-team@company.org"
+          escalate: "sre-team@company.org"
 
   # slo thresholds for individual domains, slo_classes and slo_types
   - name: slo-thresholds
@@ -50,4 +52,3 @@ groups:
         slo_type: latency99
         percentile: 99
         le: 12.0
-


### PR DESCRIPTION
- add escalate label to SLO alerts
- improve `slo:violation_ratio` in order to produce result in case there are no errors in given `slo_time_range`
- split `slo:events_over_time` computation into more groups