### PR TITLE
fix: use strict unmarshal in relabel module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-
+- [#54](https://github.com/seznam/slo-exporter/pull/54) Use strict unmarshal in relabel module
 - [#57](https://github.com/seznam/slo-exporter/pull/57) Upgrade to Go 1.16
 
 ## [v6.8.0] 2021-03-24

--- a/pkg/relabel/relabel.go
+++ b/pkg/relabel/relabel.go
@@ -2,13 +2,14 @@ package relabel
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/viper"
 	"github.com/seznam/slo-exporter/pkg/event"
 	"github.com/seznam/slo-exporter/pkg/pipeline"
 	"github.com/seznam/slo-exporter/pkg/stringmap"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
-	"time"
 
 	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/sirupsen/logrus"
@@ -30,7 +31,7 @@ func NewFromViper(viperConfig *viper.Viper, logger logrus.FieldLogger) (*eventRe
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
-	if err := yaml.Unmarshal(marshalledConfig, &relabelConf); err != nil {
+	if err := yaml.UnmarshalStrict(marshalledConfig, &relabelConf); err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 	return NewFromConfig(relabelConf, logger)


### PR DESCRIPTION
Configuration of relabel module wasn't checked against proper structure. This MR replaces `yaml.Unmarshal` with `yaml.UnmarshalStrict`