### PR TITLE
WIP: fix: revive install without side effects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ $(RELEASE_NOTES): $(TMP_DIR)
 .PHONY: revive
 revive:
 	@echo "Downloading linter revive..."
-	go get -u github.com/mgechev/revive
+	go install github.com/mgechev/revive@v1.0.7
 
 .PHONY: all
 all: lint test-and-coverage build

--- a/docs/modules/kafka_ingester.md
+++ b/docs/modules/kafka_ingester.md
@@ -54,6 +54,6 @@ For every received message from Kafka:
 ```
 
 Strictly speaking, none of the keys is mandatory, however please note that:
-- Event with explicitly set Quantity=0 is basically noop for Producer module. To give an example, prometheusExporter does not increment any SLO metric for such events.
+- Event with explicitly set quantity=0 is basically noop for Producer module. To give an example, prometheusExporter does not increment any SLO metric for such events.
 - Event with empty Metadata does not allow much logic in following modules.
 - In case you want to allow ingesting events without SLO classification, you need to make sure that all events are classified within rest of the SLO exporter pipeline.

--- a/examples/kafka/README.md
+++ b/examples/kafka/README.md
@@ -1,0 +1,24 @@
+# Kafka ingester SLO example
+
+This example shows a simple configuration of slo-exporter using
+[`kafka_ingester`](/docs/modules/kafka_ingester.md)
+as a source of data in order to compute SLO of a server which publishes events through Kafka.
+
+#### How to run it
+In root of the repo
+```bash
+make build
+cd examples/kafka
+docker-compose up -d
+```
+Once started see http://localhost:8080/metrics.
+
+## How SLO is computed
+Kafkacat is used to publish events to Kafka on behalf of an imaginary server. Each event contains its SLO classification together with metadata.
+
+## Observed SLO types
+#### `availability`
+All events whose "result" metadata's key equals to "OK" are considered successful.
+
+#### `quality`
+All events whose all quality degradation tracking metadata's key(s) equals to 0 are considered successful.  

--- a/examples/kafka/docker-compose.yaml
+++ b/examples/kafka/docker-compose.yaml
@@ -1,0 +1,96 @@
+version: '3'
+services:
+  slo-exporter:
+    image: slo_exporter
+    depends_on:
+      - topic-initialization
+    ports:
+      - 8080:8080
+    working_dir: /slo-exporter
+    command:
+      - "--config-file=/slo-exporter/slo_exporter.yaml"
+    volumes:
+      - ./slo-exporter/:/slo-exporter/
+
+  topic-initialization:
+    image: confluentinc/cp-kafka:6.0.2
+    command: kafka-topics --create --topic slo-exporter --partitions 4 --replication-factor 2 --if-not-exists --bootstrap-server kafka-1:9092
+    depends_on:
+      - kafka-1
+      - kafka-2
+      - kafka-3
+
+  kafkacat:
+    image: confluentinc/cp-kafkacat
+    command: |
+     bash -c "
+       while true;
+       do
+         echo '{\"quantity\": 1, \"slo_classification\": {\"app\": \"fooApp\", \"domain\": \"testDomain\", \"class\": \"critical\"}, \"metadata\": {\"name\": \"foo\", \"degradation_slave_response\": \"1\", \"result\": \"success\"}}' | kafkacat -P -b kafka-1:9092,kafka-2:9092,kafka-3:9092 -t slo-exporter -p 0
+         sleep 1
+       done"
+    depends_on:
+      - topic-initialization
+
+  zookeeper-1:
+    image: confluentinc/cp-zookeeper:6.0.2
+    environment:
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_CLIENT_PORT: 22181
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_INIT_LIMIT: 5
+      ZOOKEEPER_SYNC_LIMIT: 2
+      ZOOKEEPER_SERVERS: zookeeper-1:22888:23888;zookeeper-2:32888:33888;zookeeper-3:42888:43888
+
+  zookeeper-2:
+    image: confluentinc/cp-zookeeper:6.0.2
+    environment:
+      ZOOKEEPER_SERVER_ID: 2
+      ZOOKEEPER_CLIENT_PORT: 32181
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_INIT_LIMIT: 5
+      ZOOKEEPER_SYNC_LIMIT: 2
+      ZOOKEEPER_SERVERS: zookeeper-1:22888:23888;zookeeper-2:32888:33888;zookeeper-3:42888:43888
+
+  zookeeper-3:
+    image: confluentinc/cp-zookeeper:6.0.2
+    environment:
+      ZOOKEEPER_SERVER_ID: 3
+      ZOOKEEPER_CLIENT_PORT: 42181
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_INIT_LIMIT: 5
+      ZOOKEEPER_SYNC_LIMIT: 2
+      ZOOKEEPER_SERVERS: zookeeper-1:22888:23888;zookeeper-2:32888:33888;zookeeper-3:42888:43888
+
+  kafka-1:
+    image: confluentinc/cp-kafka:6.0.2
+    depends_on:
+      - zookeeper-1
+      - zookeeper-2
+      - zookeeper-3
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:22181,zookeeper-2:22181,zookeeper-3:22181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:9092
+
+  kafka-2:
+    image: confluentinc/cp-kafka:6.0.2
+    depends_on:
+      - zookeeper-1
+      - zookeeper-2
+      - zookeeper-3
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:22181,zookeeper-2:22181,zookeeper-3:22181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:9092
+
+  kafka-3:
+    image: confluentinc/cp-kafka:6.0.2
+    depends_on:
+      - zookeeper-1
+      - zookeeper-2
+      - zookeeper-3
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:22181,zookeeper-2:22181,zookeeper-3:22181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:9092

--- a/examples/kafka/slo-exporter/slo_exporter.yaml
+++ b/examples/kafka/slo-exporter/slo_exporter.yaml
@@ -1,0 +1,23 @@
+webServerListenAddress: "0.0.0.0:8080"
+
+pipeline: ["kafkaIngester", "eventKeyGenerator", "sloEventProducer", "prometheusExporter"]
+
+modules:
+  kafkaIngester:
+    brokers:
+      - "kafka-1:9092"
+      - "kafka-2:9092"
+      - "kafka-3:9092"
+    topic: slo-exporter
+    groupId: slo-exporter
+    logKafkaEvents: true
+
+  eventKeyGenerator:
+    metadataKeys:
+    - "name"
+
+  sloEventProducer:
+    rulesFiles:
+      - "slo_rules.yaml"
+
+  prometheusExporter: {}

--- a/examples/kafka/slo-exporter/slo_rules.yaml
+++ b/examples/kafka/slo-exporter/slo_rules.yaml
@@ -1,0 +1,17 @@
+rules:
+  - failure_conditions:
+      - key: result
+        operator: isNotEqualTo
+        value: "success"
+    additional_metadata:
+      slo_type: availability
+      slo_version: 1
+
+  # Mark event as failed for slo_type: quality if any of the observed quality degradations occurred
+  - failure_conditions:
+      - key: degradation_slave_response
+        operator: numberIsHigherThan
+        value: 0
+    additional_metadata:
+      slo_type: quality
+      slo_version: 1


### PR DESCRIPTION
Previously there was used `go get ...` which updated `go.mod` file.

Now `go install ....@TAG` install module, which states by doc:
>  This is useful for installing executables without affecting the dependencies of the main module.