### PR TITLE
fix: do not update go.mod by running `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ $(RELEASE_NOTES): $(TMP_DIR)
 .PHONY: revive
 revive:
 	@echo "Downloading linter revive..."
-	go get -u github.com/mgechev/revive
+	go install github.com/mgechev/revive@v1.0.7
 
 .PHONY: all
 all: lint test-and-coverage build


### PR DESCRIPTION
Previously there was used `go get ...` which updated `go.mod` file.

Now `go install ....@TAG` install module, which states by doc:
>  This is useful for installing executables without affecting the dependencies of the main module.