### PR TITLE
docs: add missing mention of the envoyAccessLogServer module

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,7 @@ modules:
 Only produces new events from the specified data source.
   - [`tailer`](modules/tailer.md)
   - [`prometheusIngester`](modules/prometheus_ingester.md)
+  - [`envoyAccessLogServer`](modules/envoy_access_log_server.md)
   
 ##### Processors:
 Reads input events, does some processing based in the module type and produces modified event.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ Only produces new events from the specified data source.
   - [`tailer`](modules/tailer.md)
   - [`prometheusIngester`](modules/prometheus_ingester.md)
   - [`envoyAccessLogServer`](modules/envoy_access_log_server.md)
+  - [`kafkaIngester`](modules/kafka_ingester.md)
   
 ##### Processors:
 Reads input events, does some processing based in the module type and produces modified event.


### PR DESCRIPTION
@david-vavra 

I noticed we forgot to link the module from the modules docs.