### PR TITLE
fix: log exceeded limit as info instead of warning

### DIFF
--- a/pkg/prometheus_exporter/prometheus_exporter.go
+++ b/pkg/prometheus_exporter/prometheus_exporter.go
@@ -3,11 +3,11 @@ package prometheus_exporter
 import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/seznam/slo-exporter/pkg/event"
 	"github.com/seznam/slo-exporter/pkg/pipeline"
 	"github.com/seznam/slo-exporter/pkg/stringmap"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"time"
 )
 
@@ -226,7 +226,7 @@ func (e *PrometheusSloEventExporter) processEvent(newEvent *event.Slo) error {
 	labels := e.labelsFromEvent(newEvent)
 
 	if e.isCardinalityExceeded(newEvent.Key) {
-		e.logger.Warnf("event key '%s' exceeded limit '%d', masked as '%s'", newEvent.Key, e.eventKeyLimit, e.exceededKeyLimitPlaceholder)
+		e.logger.Infof("event key '%s' exceeded limit '%d', masked as '%s'", newEvent.Key, e.eventKeyLimit, e.exceededKeyLimitPlaceholder)
 		labels[e.labelNames.EventKey] = e.exceededKeyLimitPlaceholder
 	}
 


### PR DESCRIPTION
I would prefer log exceeded limit as info. To log warning+ and skip info logs.