### PR TITLE
fix: prometheus ingester: skip empty result - miss scrape interval

### DIFF
--- a/pkg/prometheus_ingester/query_executor.go
+++ b/pkg/prometheus_ingester/query_executor.go
@@ -282,7 +282,10 @@ func (q *queryExecutor) processMatrixResultAsIncrease(matrix model.Matrix, ts ti
 				metric:   singleMetricSampleStream.Metric,
 			}
 		}
-		q.previousResult = currentResult
+		if len(currentResult.metrics) > 0 {
+			// skip empty result - miss scrape interval
+			q.previousResult = currentResult
+		}
 	}()
 	return outChan
 }


### PR DESCRIPTION
Fixed bug https://github.com/seznam/slo-exporter/issues/74