### PR TITLE
feat: sync Grafana dashboards

### DIFF
--- a/examples/all_in_one/README.md
+++ b/examples/all_in_one/README.md
@@ -33,4 +33,4 @@ To access Grafana and Prometheus:
 #  Password: admin
 ```
 
-Please note that it may take up to 5 minutes until Grafana dashboards will show any data. This is caused by evaluation interval of the included Prometheus recording rules.
+**Please note that it may take up to 5 minutes until Grafana dashboards will show any data. This is caused by evaluation interval of the included Prometheus recording rules.**

--- a/examples/all_in_one/docker-compose.yaml
+++ b/examples/all_in_one/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       - ./prometheus/alerts:/prometheus/alerts
 
   grafana:
-    image: grafana/grafana:7.3.0
+    image: grafana/grafana:8.3.3
     depends_on:
       - prometheus
     ports:

--- a/examples/all_in_one/grafana/provisioning/dashboards/SLO_Effective_Burn-rate.json
+++ b/examples/all_in_one/grafana/provisioning/dashboards/SLO_Effective_Burn-rate.json
@@ -1,24 +1,69 @@
 {
+  "__inputs": [
+    {
+      "name": "Prometheus",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.2.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph (old)",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
+        "$$hashKey": "object:28",
         "builtIn": 1,
         "datasource": "Prometheus",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
+  "fiscalYearStartMonth": 0,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2921,
-  "iteration": 1604580107545,
+  "id": null,
+  "iteration": 1640880027707,
   "links": [
     {
+      "$$hashKey": "object:105",
       "icon": "external link",
       "includeVars": true,
       "tags": [
@@ -30,6 +75,7 @@
       "type": "dashboards"
     },
     {
+      "$$hashKey": "object:202",
       "icon": "external link",
       "tags": [
         "SLO",
@@ -38,35 +84,71 @@
       ],
       "targetBlank": true,
       "type": "dashboards"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "SLO Detailed",
+      "tooltip": "Show SLO Detailed dashboard (info about tresholds etc.)",
+      "type": "link",
+      "url": "https://grafana/d/lRKeWGZGk/slo-detailed?var-slo_version=$slo_version&var-slo_domain=$slo_domain&var-slo_type=$slo_type&var-slo_class=$slo_class&var-slo_time_range=4w&var-latency_slo_type=All&var-namespace=$namespace"
     }
   ],
+  "liveNow": false,
   "panels": [
     {
+      "collapsed": false,
       "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
       },
+      "id": 38,
+      "panels": [],
+      "title": "README",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 1
       },
       "id": 28,
       "options": {
         "content": "Precomputed SLO burn-rate multiplied with events rate coefficient. The result, as diplayed in the graphs, is what is used for SLO burn rate alerting.\n\nWe discussed the need for events rate coefficient in [one of our articles.](https://medium.com/@sklik.devops/our-journey-towards-slo-based-alerting-bd8bbe23c1d6)",
         "mode": "markdown"
       },
-      "pluginVersion": "7.3.0",
+      "pluginVersion": "8.2.2",
       "timeFrom": null,
       "timeShift": null,
       "title": "README",
       "type": "text"
     },
     {
+      "collapsed": false,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 36,
+      "panels": [],
+      "repeat": "slo_type",
+      "title": "LATENCY90 BURN-RATE (ALL / 1h)",
+      "type": "row"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -74,31 +156,38 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
-          "links": []
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "SLO Drilldown - ${__field.labels.slo_domain} - ${__field.labels.slo_class} - ${__field.labels.slo_type}",
+              "url": "https://grafana/d/rPOkReFMz/slo-drilldown?orgId=1&&var-slo_version=${__field.labels.slo_version}&var-slo_domain=${__field.labels.slo_domain}&var-slo_class=${__field.labels.slo_class}&var-slo_time_range=${__field.labels.slo_time_range}&var-slo_type=${__field.labels.slo_type}&var-namespace=${__field.labels.namespace}&var-offset=All&var-cluster=All&var-instance=All&${__url_time_range}"
+            }
+          ]
         },
         "overrides": []
       },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 11,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 5
       },
       "hiddenSeries": false,
       "id": 24,
       "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "max",
+        "sortDesc": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -109,34 +198,46 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "7.3.0",
+      "pluginVersion": "8.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeat": "slo_type",
+      "repeat": "slo_class",
       "repeatDirection": "v",
-      "scopedVars": {
-        "slo_type": {
-          "selected": false,
-          "text": "latency90",
-          "value": "latency90"
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:620",
+          "alias": "/Events rate.+/",
+          "fill": 1,
+          "lines": true,
+          "points": true
         }
-      },
-      "seriesOverrides": [],
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "\nslo:burn_rate{slo_domain=\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_time_range=~\"$slo_time_range\", namespace=\"$namespace\"}\n* on(slo_domain, slo_class, slo_type, namespace) group_left() \nslo:events_rate_coefficient{slo_time_range=\"$request_rate_time_range\"}",
+          "exemplar": true,
+          "expr": "\nslo:burn_rate{slo_domain=~\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_time_range=~\"$slo_time_range\", namespace=\"$namespace\"}\n* on(slo_domain, slo_class, slo_type, namespace) group_left() \nslo:events_rate_coefficient{slo_time_range=\"$request_rate_time_range\", namespace=\"$namespace\"}",
           "hide": false,
+          "instant": false,
           "interval": "",
-          "legendFormat": "{{ slo_class }} / {{ slo_time_range }}",
+          "legendFormat": "Burn rate {{ slo_domain }} {{ slo_class }} {{ slo_type }} / {{ slo_time_range }}",
           "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "max(slo:events_rate_coefficient{slo_domain=~\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_time_range=~\"$slo_time_range\", namespace=\"$namespace\"}) by (slo_domain, slo_class)",
+          "hide": true,
+          "interval": "",
+          "legendFormat": "Events rate coeff {{ slo_domain }} {{ slo_class }}",
+          "refId": "B"
         }
       ],
       "thresholds": [
         {
+          "$$hashKey": "object:101",
           "colorMode": "warning",
           "fill": false,
           "fillColor": "rgba(50, 116, 217, 0.2)",
@@ -153,7 +254,7 @@
       "title": "$slo_type Burn-rate ($slo_class / $slo_time_range)",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -166,6 +267,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:71",
           "decimals": 3,
           "format": "short",
           "label": null,
@@ -175,252 +277,7 @@
           "show": true
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": "0",
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "hiddenSeries": false,
-      "id": 29,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "7.3.0",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "repeatDirection": "v",
-      "repeatIteration": 1604580107545,
-      "repeatPanelId": 24,
-      "scopedVars": {
-        "slo_type": {
-          "selected": false,
-          "text": "latency99",
-          "value": "latency99"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "\nslo:burn_rate{slo_domain=\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_time_range=~\"$slo_time_range\", namespace=\"$namespace\"}\n* on(slo_domain, slo_class, slo_type, namespace) group_left() \nslo:events_rate_coefficient{slo_time_range=\"$request_rate_time_range\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "{{ slo_class }} / {{ slo_time_range }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [
-        {
-          "colorMode": "warning",
-          "fill": false,
-          "fillColor": "rgba(50, 116, 217, 0.2)",
-          "line": true,
-          "lineColor": "#FA6400",
-          "op": "gt",
-          "value": 1,
-          "yaxis": "left"
-        }
-      ],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$slo_type Burn-rate ($slo_class / $slo_time_range)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 3,
-          "format": "short",
-          "label": null,
-          "logBase": 2,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": "0",
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 17
-      },
-      "hiddenSeries": false,
-      "id": 30,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "7.3.0",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "repeatDirection": "v",
-      "repeatIteration": 1604580107545,
-      "repeatPanelId": 24,
-      "scopedVars": {
-        "slo_type": {
-          "selected": false,
-          "text": "availability",
-          "value": "availability"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "\nslo:burn_rate{slo_domain=\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_time_range=~\"$slo_time_range\", namespace=\"$namespace\"}\n* on(slo_domain, slo_class, slo_type, namespace) group_left() \nslo:events_rate_coefficient{slo_time_range=\"$request_rate_time_range\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "{{ slo_class }} / {{ slo_time_range }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [
-        {
-          "colorMode": "warning",
-          "fill": false,
-          "fillColor": "rgba(50, 116, 217, 0.2)",
-          "line": true,
-          "lineColor": "#FA6400",
-          "op": "gt",
-          "value": 1,
-          "yaxis": "left"
-        }
-      ],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$slo_type Burn-rate ($slo_class / $slo_time_range)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 3,
-          "format": "short",
-          "label": null,
-          "logBase": 2,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
+          "$$hashKey": "object:72",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -436,7 +293,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 26,
+  "schemaVersion": 31,
   "style": "dark",
   "tags": [
     "SLO, SRE"
@@ -448,6 +305,7 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:violation_ratio_threshold{}, slo_version)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -455,45 +313,51 @@
         "multi": false,
         "name": "slo_version",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{}, slo_version)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{}, slo_version)",
+          "refId": "Prometheus-slo_version-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".+",
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\"}, slo_domain)",
+        "description": null,
         "error": null,
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": null,
-        "multi": false,
+        "multi": true,
         "name": "slo_domain",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\"}, slo_domain)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\"}, slo_domain)",
+          "refId": "Prometheus-slo_domain-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".+",
         "current": {},
         "datasource": "Prometheus",
-        "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_class)",
+        "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=~\"$slo_domain\"}, slo_class)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -501,13 +365,15 @@
         "multi": true,
         "name": "slo_class",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_class)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=~\"$slo_domain\"}, slo_class)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -517,6 +383,7 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:burn_rate{slo_version=\"$slo_version\"}, slo_time_range)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -524,13 +391,15 @@
         "multi": true,
         "name": "slo_time_range",
         "options": [],
-        "query": "label_values(slo:burn_rate{slo_version=\"$slo_version\"}, slo_time_range)",
+        "query": {
+          "query": "label_values(slo:burn_rate{slo_version=\"$slo_version\"}, slo_time_range)",
+          "refId": "Prometheus-slo_time_range-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -540,20 +409,41 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values( slo:events_rate_coefficient{slo_version=\"$slo_version\"}, slo_time_range)",
-        "error": null,
+        "description": null,
+        "error": {
+          "config": {
+            "headers": {
+              "X-Grafana-Org-Id": 1
+            },
+            "hideFromInspector": true,
+            "method": "GET",
+            "retry": 0,
+            "url": "api/datasources/proxy/20/api/v1/series?match%5B%5D=%20slo%3Aevents_rate_coefficient%7Bslo_version%3D%226%22%7D&start=1640707208&end=1640880008"
+          },
+          "data": {
+            "error": "Bad Gateway",
+            "message": "Bad Gateway",
+            "response": ""
+          },
+          "message": "Bad Gateway",
+          "status": 502,
+          "statusText": "Bad Gateway"
+        },
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "request_rate_time_range",
         "options": [],
-        "query": "label_values( slo:events_rate_coefficient{slo_version=\"$slo_version\"}, slo_time_range)",
+        "query": {
+          "query": "label_values( slo:events_rate_coefficient{slo_version=\"$slo_version\"}, slo_time_range)",
+          "refId": "Prometheus-request_rate_time_range-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -563,6 +453,7 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_type)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -570,13 +461,15 @@
         "multi": true,
         "name": "slo_type",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_type)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_type)",
+          "refId": "Prometheus-slo_type-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -585,7 +478,8 @@
         "allValue": null,
         "current": {},
         "datasource": "Prometheus",
-        "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, namespace)",
+        "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=~\"$slo_domain\"}, namespace)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -593,13 +487,15 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, namespace)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=~\"$slo_domain\"}, namespace)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -637,5 +533,5 @@
   "timezone": "",
   "title": "SLO Effective Burn-rate",
   "uid": "5r2KMMWMk",
-  "version": 8
+  "version": 25
 }

--- a/examples/all_in_one/grafana/provisioning/dashboards/SLO_detailed.json
+++ b/examples/all_in_one/grafana/provisioning/dashboards/SLO_detailed.json
@@ -1,15 +1,25 @@
 {
+  "__inputs": [
+    {
+      "name": "Prometheus",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "__requires": [
     {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.0.0"
+      "version": "8.2.2"
     },
     {
       "type": "panel",
       "id": "graph",
-      "name": "Graph",
+      "name": "Graph (old)",
       "version": ""
     },
     {
@@ -17,12 +27,6 @@
       "id": "prometheus",
       "name": "Prometheus",
       "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": ""
     },
     {
       "type": "panel",
@@ -34,24 +38,33 @@
   "annotations": {
     "list": [
       {
+        "$$hashKey": "object:25",
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": "Prometheus",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "description": "",
   "editable": true,
+  "fiscalYearStartMonth": 0,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1593202166365,
+  "iteration": 1640877138688,
   "links": [
     {
+      "$$hashKey": "object:201",
       "icon": "external link",
       "includeVars": false,
       "tags": [
@@ -63,6 +76,7 @@
       "type": "dashboards"
     },
     {
+      "$$hashKey": "object:224",
       "icon": "external link",
       "tags": [
         "SRE",
@@ -73,6 +87,7 @@
       "type": "dashboards"
     }
   ],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
@@ -82,6 +97,159 @@
         "w": 24,
         "x": 0,
         "y": 0
+      },
+      "id": 430,
+      "panels": [],
+      "title": "ON CALL",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "opsgenie teams",
+              "url": "https://opsgenie.com/teams/list"
+            }
+          ],
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 428,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "/^Value$/",
+          "values": true
+        },
+        "text": {},
+        "textMode": "name"
+      },
+      "pluginVersion": "8.2.2",
+      "targets": [
+        {
+          "displayType": "Regular",
+          "exemplar": true,
+          "expr": "max(slo:stable_version{slo_domain=\"$slo_domain\",slo_version=\"$slo_version\"}) by (team)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{team}}",
+          "refId": "A",
+          "valueHandler": "Number Threshold"
+        }
+      ],
+      "title": "Responsible team",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OpsGenie Teams",
+              "url": "https://opsgenie.com/teams/list"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 393,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "/^Value$/",
+          "values": true
+        },
+        "text": {},
+        "textMode": "name"
+      },
+      "pluginVersion": "8.2.2",
+      "targets": [
+        {
+          "displayType": "Regular",
+          "exemplar": true,
+          "expr": "max(slo:stable_version{slo_domain=\"$slo_domain\",slo_version=\"$slo_version\"}) by (escalate)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{escalate}}",
+          "refId": "A",
+          "valueHandler": "Number Threshold"
+        }
+      ],
+      "title": "Shadow (non-working hours) escalation",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
       },
       "id": 256,
       "panels": [],
@@ -94,18 +262,32 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "decimals": 2,
-          "mappings": [
+          "links": [
             {
-              "id": 0,
-              "op": "=",
-              "text": "N/A",
-              "type": 1,
-              "value": "null"
+              "targetBlank": true,
+              "title": "SLO Drilldown - ${__field.labels.slo_domain} - ${__field.labels.slo_class} - ${__field.labels.slo_type}",
+              "url": "https://grafana/d/rPOkReFMz/slo-drilldown?orgId=1&var-slo_version=${__field.labels.slo_version}&var-slo_domain=${__field.labels.slo_domain}&var-slo_class=${__field.labels.slo_class}&var-slo_time_range=${__field.labels.slo_time_range}&var-slo_type=${__field.labels.slo_type}&var-namespace=${__field.labels.namespace}&var-instance=All&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "SLO Effective Burn-rate - ${__field.labels.slo_domain} - ${__field.labels.slo_class} - ${__field.labels.slo_type}",
+              "url": "https://grafana/d/5r2KMMWMk/slo-effective-burn-rate?orgId=1&&var-slo_version=${__field.labels.slo_version}&var-slo_domain=${__field.labels.slo_domain}&var-slo_class=${__field.labels.slo_class}&var-slo_time_range=${__field.labels.slo_time_range}&var-slo_type=All&var-namespace=${__field.labels.namespace}&var-offset=All&var-cluster=All&var-instance=All&${__url_time_range}"
             }
           ],
-          "nullValueMode": "connected",
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 1,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -131,7 +313,7 @@
         "h": 3,
         "w": 6,
         "x": 0,
-        "y": 1
+        "y": 4
       },
       "id": 52,
       "interval": null,
@@ -151,17 +333,23 @@
           "calcs": [
             "mean"
           ],
+          "fields": "",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.0",
+      "pluginVersion": "8.2.2",
       "repeat": "slo_class",
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "1 - slo:violation_ratio{slo_domain=\"$slo_domain\", slo_type=\"$slo_type\", slo_class=\"$slo_class\", slo_version=\"$slo_version\", slo_time_range=\"$slo_time_range\", namespace=\"$namespace\"}",
+          "exemplar": true,
+          "expr": "1 - max_over_time(slo:violation_ratio{slo_domain=\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=\"$slo_class\", slo_version=\"$slo_version\", slo_time_range=\"$slo_time_range\", namespace=\"$namespace\"}[5m])",
           "hide": false,
           "instant": true,
+          "interval": "",
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -175,7 +363,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 57
       },
       "id": 146,
       "panels": [],
@@ -190,19 +378,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 13
+        "y": 58
       },
       "hiddenSeries": false,
       "id": 144,
@@ -219,13 +401,19 @@
       },
       "lines": true,
       "linewidth": 1,
-      "links": [],
+      "links": [
+        {
+          "title": "SLO Drilldown",
+          "url": "https://grafana/d/rPOkReFMz/slo-drilldown?orgId=1&var-slo_version=${slo_version}&var-slo_domain=${slo_domain}&var-slo_class=${slo_class}&var-slo_time_range=${slo_time_range}&var-slo_type=${slo_type}&var-namespace=${namespace}&var-offset=All&${__url_time_range}"
+        }
+      ],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "paceLength": 10,
       "percentage": false,
+      "pluginVersion": "8.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -233,10 +421,12 @@
       "repeatDirection": "h",
       "seriesOverrides": [
         {
+          "$$hashKey": "object:498",
           "alias": "placeholder",
           "lines": false
         },
         {
+          "$$hashKey": "object:499",
           "alias": "zero",
           "lines": false
         }
@@ -252,8 +442,9 @@
           "refId": "B"
         },
         {
-          "expr": "slo:violation_ratio{slo_domain=\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=\"$slo_class\", slo_version=\"$slo_version\", slo_time_range=\"$slo_time_range\", namespace=\"$namespace\"}\n/ on (slo_class,slo_domain,slo_version, slo_type, namespace) group_left ()\n(\n    slo:violation_ratio_threshold - 1\n)\n+1",
+          "expr": "max_over_time(slo:violation_ratio{slo_domain=\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=\"$slo_class\", slo_version=\"$slo_version\", slo_time_range=\"$slo_time_range\", namespace=\"$namespace\"}[15m])\n/ on (slo_class,slo_domain,slo_version, slo_type, namespace) group_left ()\n(\n    slo:violation_ratio_threshold - 1\n)\n+1",
           "hide": false,
+          "instant": false,
           "interval": "",
           "legendFormat": "{{ slo_type }}",
           "refId": "A"
@@ -279,6 +470,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:512",
           "format": "percentunit",
           "label": null,
           "logBase": 1,
@@ -287,6 +479,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:513",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -307,7 +500,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 70
       },
       "id": 163,
       "panels": [
@@ -316,18 +509,20 @@
           "datasource": "Prometheus",
           "fieldConfig": {
             "defaults": {
-              "custom": {},
               "decimals": 2,
               "mappings": [
                 {
-                  "id": 0,
-                  "op": "=",
-                  "text": "N/A",
-                  "type": 1,
-                  "value": "null"
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
                 }
               ],
-              "nullValueMode": "connected",
+              "max": 1,
+              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -349,7 +544,7 @@
             "h": 2,
             "w": 6,
             "x": 0,
-            "y": 14
+            "y": 22
           },
           "id": 180,
           "interval": null,
@@ -369,297 +564,15 @@
               "calcs": [
                 "mean"
               ],
+              "fields": "",
               "values": false
-            }
+            },
+            "text": {},
+            "textMode": "auto"
           },
-          "pluginVersion": "7.0.0",
+          "pluginVersion": "8.0.2",
           "repeat": "slo_class",
           "repeatDirection": "h",
-          "scopedVars": {
-            "slo_class": {
-              "selected": false,
-              "text": "critical",
-              "value": "critical"
-            },
-            "slo_type": {
-              "selected": false,
-              "text": "availability",
-              "value": "availability"
-            }
-          },
-          "targets": [
-            {
-              "expr": "slo:violation_ratio_threshold{slo_class=\"$slo_class\",slo_domain=\"$slo_domain\",slo_version=\"$slo_version\", slo_type=\"$slo_type\", namespace=\"$namespace\"}",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "$slo_type $slo_class",
-          "type": "stat"
-        },
-        {
-          "cacheTimeout": null,
-          "datasource": "Prometheus",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {},
-              "decimals": 2,
-              "mappings": [
-                {
-                  "id": 0,
-                  "op": "=",
-                  "text": "N/A",
-                  "type": 1,
-                  "value": "null"
-                }
-              ],
-              "nullValueMode": "connected",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 6,
-            "x": 6,
-            "y": 14
-          },
-          "id": 339,
-          "interval": null,
-          "links": [],
-          "maxDataPoints": 100,
-          "options": {
-            "colorMode": "value",
-            "fieldOptions": {
-              "calcs": [
-                "mean"
-              ]
-            },
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "mean"
-              ],
-              "values": false
-            }
-          },
-          "pluginVersion": "7.0.0",
-          "repeat": null,
-          "repeatDirection": "h",
-          "repeatIteration": 1591090840059,
-          "repeatPanelId": 180,
-          "scopedVars": {
-            "slo_class": {
-              "selected": false,
-              "text": "high_fast",
-              "value": "high_fast"
-            },
-            "slo_type": {
-              "selected": false,
-              "text": "availability",
-              "value": "availability"
-            }
-          },
-          "targets": [
-            {
-              "expr": "slo:violation_ratio_threshold{slo_class=\"$slo_class\",slo_domain=\"$slo_domain\",slo_version=\"$slo_version\", slo_type=\"$slo_type\", namespace=\"$namespace\"}",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "$slo_type $slo_class",
-          "type": "stat"
-        },
-        {
-          "cacheTimeout": null,
-          "datasource": "Prometheus",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {},
-              "decimals": 2,
-              "mappings": [
-                {
-                  "id": 0,
-                  "op": "=",
-                  "text": "N/A",
-                  "type": 1,
-                  "value": "null"
-                }
-              ],
-              "nullValueMode": "connected",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 6,
-            "x": 12,
-            "y": 14
-          },
-          "id": 340,
-          "interval": null,
-          "links": [],
-          "maxDataPoints": 100,
-          "options": {
-            "colorMode": "value",
-            "fieldOptions": {
-              "calcs": [
-                "mean"
-              ]
-            },
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "mean"
-              ],
-              "values": false
-            }
-          },
-          "pluginVersion": "7.0.0",
-          "repeat": null,
-          "repeatDirection": "h",
-          "repeatIteration": 1591090840059,
-          "repeatPanelId": 180,
-          "scopedVars": {
-            "slo_class": {
-              "selected": false,
-              "text": "high_slow",
-              "value": "high_slow"
-            },
-            "slo_type": {
-              "selected": false,
-              "text": "availability",
-              "value": "availability"
-            }
-          },
-          "targets": [
-            {
-              "expr": "slo:violation_ratio_threshold{slo_class=\"$slo_class\",slo_domain=\"$slo_domain\",slo_version=\"$slo_version\", slo_type=\"$slo_type\", namespace=\"$namespace\"}",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "$slo_type $slo_class",
-          "type": "stat"
-        },
-        {
-          "cacheTimeout": null,
-          "datasource": "Prometheus",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {},
-              "decimals": 2,
-              "mappings": [
-                {
-                  "id": 0,
-                  "op": "=",
-                  "text": "N/A",
-                  "type": 1,
-                  "value": "null"
-                }
-              ],
-              "nullValueMode": "connected",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 6,
-            "x": 18,
-            "y": 14
-          },
-          "id": 341,
-          "interval": null,
-          "links": [],
-          "maxDataPoints": 100,
-          "options": {
-            "colorMode": "value",
-            "fieldOptions": {
-              "calcs": [
-                "mean"
-              ]
-            },
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "mean"
-              ],
-              "values": false
-            }
-          },
-          "pluginVersion": "7.0.0",
-          "repeat": null,
-          "repeatDirection": "h",
-          "repeatIteration": 1591090840059,
-          "repeatPanelId": 180,
-          "scopedVars": {
-            "slo_class": {
-              "selected": false,
-              "text": "low",
-              "value": "low"
-            },
-            "slo_type": {
-              "selected": false,
-              "text": "availability",
-              "value": "availability"
-            }
-          },
           "targets": [
             {
               "expr": "slo:violation_ratio_threshold{slo_class=\"$slo_class\",slo_domain=\"$slo_domain\",slo_version=\"$slo_version\", slo_type=\"$slo_type\", namespace=\"$namespace\"}",
@@ -685,33 +598,35 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 287
       },
       "id": 301,
       "panels": [
         {
           "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
           "datasource": "Prometheus",
           "fieldConfig": {
             "defaults": {
-              "custom": {}
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
             },
             "overrides": []
-          },
-          "format": "s",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
           },
           "gridPos": {
             "h": 2,
@@ -722,53 +637,25 @@
           "id": 199,
           "interval": null,
           "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
           "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "pluginVersion": "6.6.1",
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/^le$/",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.0.2",
           "repeat": "slo_class",
           "repeatDirection": "h",
-          "scopedVars": {
-            "latency_slo_type": {
-              "selected": false,
-              "text": "latency90",
-              "value": "latency90"
-            },
-            "slo_class": {
-              "selected": false,
-              "text": "critical",
-              "value": "critical"
-            }
-          },
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "le",
           "targets": [
             {
               "expr": "slo:violation_ratio_threshold{slo_class=\"$slo_class\",slo_domain=\"$slo_domain\",slo_version=\"$slo_version\", slo_type=\"$latency_slo_type\", namespace=\"$namespace\"}",
@@ -779,341 +666,10 @@
               "refId": "A"
             }
           ],
-          "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
           "title": "$latency_slo_type percentile threshold for $slo_class",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "",
-              "value": ""
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "Prometheus",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
-          "format": "s",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 6,
-            "x": 6,
-            "y": 29
-          },
-          "id": 355,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "pluginVersion": "6.6.1",
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "repeat": null,
-          "repeatDirection": "h",
-          "repeatIteration": 1591090840059,
-          "repeatPanelId": 199,
-          "scopedVars": {
-            "latency_slo_type": {
-              "selected": false,
-              "text": "latency90",
-              "value": "latency90"
-            },
-            "slo_class": {
-              "selected": false,
-              "text": "high_fast",
-              "value": "high_fast"
-            }
-          },
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "le",
-          "targets": [
-            {
-              "expr": "slo:violation_ratio_threshold{slo_class=\"$slo_class\",slo_domain=\"$slo_domain\",slo_version=\"$slo_version\", slo_type=\"$latency_slo_type\", namespace=\"$namespace\"}",
-              "format": "table",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "$latency_slo_type percentile threshold for $slo_class",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "",
-              "value": ""
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "Prometheus",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
-          "format": "s",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 6,
-            "x": 12,
-            "y": 29
-          },
-          "id": 356,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "pluginVersion": "6.6.1",
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "repeat": null,
-          "repeatDirection": "h",
-          "repeatIteration": 1591090840059,
-          "repeatPanelId": 199,
-          "scopedVars": {
-            "latency_slo_type": {
-              "selected": false,
-              "text": "latency90",
-              "value": "latency90"
-            },
-            "slo_class": {
-              "selected": false,
-              "text": "high_slow",
-              "value": "high_slow"
-            }
-          },
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "le",
-          "targets": [
-            {
-              "expr": "slo:violation_ratio_threshold{slo_class=\"$slo_class\",slo_domain=\"$slo_domain\",slo_version=\"$slo_version\", slo_type=\"$latency_slo_type\", namespace=\"$namespace\"}",
-              "format": "table",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "$latency_slo_type percentile threshold for $slo_class",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "",
-              "value": ""
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "Prometheus",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
-          "format": "s",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 6,
-            "x": 18,
-            "y": 29
-          },
-          "id": 357,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "pluginVersion": "6.6.1",
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "repeat": null,
-          "repeatDirection": "h",
-          "repeatIteration": 1591090840059,
-          "repeatPanelId": 199,
-          "scopedVars": {
-            "latency_slo_type": {
-              "selected": false,
-              "text": "latency90",
-              "value": "latency90"
-            },
-            "slo_class": {
-              "selected": false,
-              "text": "low",
-              "value": "low"
-            }
-          },
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "le",
-          "targets": [
-            {
-              "expr": "slo:violation_ratio_threshold{slo_class=\"$slo_class\",slo_domain=\"$slo_domain\",slo_version=\"$slo_version\", slo_type=\"$latency_slo_type\", namespace=\"$namespace\"}",
-              "format": "table",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "$latency_slo_type percentile threshold for $slo_class",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "",
-              "value": ""
-            }
-          ],
-          "valueName": "current"
+          "type": "stat"
         }
       ],
       "repeat": "latency_slo_type",
@@ -1121,143 +677,88 @@
       "type": "row"
     }
   ],
-  "refresh": "5s",
-  "schemaVersion": 25,
+  "refresh": "1m",
+  "schemaVersion": 31,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "SLO, SRE"
+  ],
   "templating": {
     "list": [
       {
-          "allValue": null,
-          "datasource": "Prometheus",
-          "definition": "label_values(slo:stable_version{enabled!=\"false\"}, slo_version)",
-          "hide": 0,
-          "includeAll": false,
-          "label": null,
-          "multi": false,
-          "name": "slo_version",
-          "options": [],
-          "query": "label_values(slo:stable_version{enabled!=\"false\"}, slo_version)",
-          "refresh": 2,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "label_values(slo:violation_ratio_threshold{}, slo_version)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "slo_version",
+        "options": [],
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{}, slo_version)",
+          "refId": "Prometheus-slo_version-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       },
       {
         "allValue": null,
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\"}, slo_domain)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "slo_domain",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\"}, slo_domain)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\"}, slo_domain)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": "",
         "current": {},
         "datasource": "Prometheus",
-        "definition": "query_result(slo:violation_ratio_threshold{slo_version=~\"$slo_version\", slo_domain=~\"$slo_domain\"})",
-        "hide": 0,
-        "includeAll": true,
-        "label": "",
-        "multi": true,
-        "name": "slo_class",
-        "options": [],
-        "query": "query_result(slo:violation_ratio_threshold{slo_version=~\"$slo_version\", slo_domain=~\"$slo_domain\"})",
-        "refresh": 2,
-        "regex": "/slo_class=\"([^\"]+)\"/",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {
-          "selected": true,
-          "text": "5m",
-          "value": "5m"
-        },
-        "datasource": "Prometheus",
-        "definition": "label_values(slo_time_range)",
-        "hide": 0,
-        "includeAll": false,
-        "label": null,
-        "multi": false,
-        "name": "slo_time_range",
-        "options": [],
-        "query": "label_values(slo_time_range)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": ".*",
-        "current": {},
-        "datasource": "Prometheus",
-        "definition": "query_result(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"})",
+        "definition": "label_values(slo:violation_ratio{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_type)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "",
         "multi": true,
         "name": "slo_type",
         "options": [],
-        "query": "query_result(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"})",
+        "query": {
+          "query": "label_values(slo:violation_ratio{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_type)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
-        "regex": "/slo_type=\"([^\"]+)\"/",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": ".*",
-        "current": {},
-        "datasource": "Prometheus",
-        "definition": "query_result(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\", slo_type=~\"$slo_type\"})",
-        "hide": 2,
-        "includeAll": true,
-        "label": "",
-        "multi": true,
-        "name": "latency_slo_type",
-        "options": [],
-        "query": "query_result(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\", slo_type=~\"$slo_type\"})",
-        "refresh": 2,
-        "regex": "/slo_type=\"(latency[^\"]*)\"/",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -1266,20 +767,102 @@
         "allValue": null,
         "current": {},
         "datasource": "Prometheus",
-        "definition": "query_result(slo:violation_ratio_threshold{slo_version=~\"$slo_version\", slo_domain=~\"$slo_domain\"})",
+        "definition": "label_values(slo:violation_ratio_threshold{slo_version=~\"$slo_version\", slo_domain=~\"$slo_domain\", slo_type=~\"$slo_type\"}, slo_class)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "",
+        "multi": true,
+        "name": "slo_class",
+        "options": [],
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=~\"$slo_version\", slo_domain=~\"$slo_domain\", slo_type=~\"$slo_type\"}, slo_class)",
+          "refId": "Prometheus-slo_class-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "label_values(slo_time_range)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "slo_time_range",
+        "options": [],
+        "query": {
+          "query": "label_values(slo_time_range)",
+          "refId": "Prometheus-slo_time_range-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\", slo_type=~\"$slo_type\", slo_type=~\".*latency.*\"}, slo_type)",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": true,
+        "label": "",
+        "multi": true,
+        "name": "latency_slo_type",
+        "options": [],
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\", slo_type=~\"$slo_type\", slo_type=~\".*latency.*\"}, slo_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, namespace)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "query_result(slo:violation_ratio_threshold{slo_version=~\"$slo_version\", slo_domain=~\"$slo_domain\"})",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, namespace)",
+          "refId": "Prometheus-namespace-Variable-Query"
+        },
         "refresh": 2,
-        "regex": "/namespace=\"([^\"]+)\"/",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -1315,7 +898,7 @@
     ]
   },
   "timezone": "",
-  "title": "SLO detailed",
+  "title": "SLO Detailed",
   "uid": "lRKeWGZGk",
-  "version": 3
+  "version": 27
 }

--- a/examples/all_in_one/grafana/provisioning/dashboards/SLO_drilldown.json
+++ b/examples/all_in_one/grafana/provisioning/dashboards/SLO_drilldown.json
@@ -1,4 +1,52 @@
 {
+  "__inputs": [
+    {
+      "name": "Prometheus",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.2.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph (old)",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table-old",
+      "name": "Table (old)",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -8,16 +56,37 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
+  "fiscalYearStartMonth": 0,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 3223,
-  "iteration": 1611139373526,
-  "links": [],
+  "id": null,
+  "iteration": 1640879333367,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "SLO Detailed",
+      "tooltip": "SLO Detailed dashboard",
+      "type": "link",
+      "url": "https://grafana/d/lRKeWGZGk/slo-detailed?orgId=1&var-slo_domain=$slo_domain&var-slo_type=$slo_type&$var-slo_class=$slo_class&$var-namespace=$namespace"
+    }
+  ],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": true,
@@ -32,12 +101,6 @@
       "panels": [
         {
           "datasource": "Prometheus",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "gridPos": {
             "h": 8,
             "w": 24,
@@ -46,13 +109,12 @@
           },
           "id": 20,
           "options": {
-            "content": "Drilldown dashboard allows to you to find out what application and event_key was cause of the SLO error budget decrease.\n\nHow to use it:\n\n### 1. Select variables based on your are of interest\n \n *Note: Selecting long SLO time range brings unecessary load for the monitoring stack. Depending on the amount of ingested data, it is even possible that the drilldown tables (per app, per app and event_key) won't be loaded due to time out.*\n \n ***General rule of thumb is that you should select the same SLO time range as was in the SLO burn-rate alert you are responding for***\n\n\n### 2. On the first graph, select the time range in which the error budget decrease occured.\n\n*Note: the second graph of error budget is included with a time offset (equal to chosen SLO time range) so that you can see if the current change of error budget wasn't by any chance caused by some larger amount of failed/successful events aging out from history.* \n\n### 3. Profit from the SLO drilldown. :)",
+            "content": "Drilldown dashboard allows to you to find out what application and event_key was cause of the SLO error budget decrease.\n\nHow to use it:\n\n### 1. Select variables based on your area of interest.\n \n *Note: Selecting long SLO time range brings unnecessary load for the monitoring stack. Depending on the amount of ingested data, it is even possible that the drilldown tables (per app, per app and event_key) won't be loaded due to time out.*\n \n ***General rule of thumb is that you should select the same SLO time range as was in the SLO burn-rate alert you are responding for.***\n\n\n### 2. On the first graph, select the time range of your interest. Typically you want to select area with burn-rate increase that you are trying to investigate.\n\n*Note: time range of the second graph is shifted by a chosen SLO time range so that you can see if the current change of error budget wasn't by any chance caused by some larger amount of failed/successful events aging out from history.* \n\n### 3. Uncollapse the tables in the last two rows which display total count of failed events by individual apps and apps, event_keys.\n\n### 4. Check offset graph panel in case troubleshooting unclear sudden changes of error budget.\nIn case reason of error budget decrease is not clear yet, focus also on the graph panel visualizing error budget change (together with requests count) with offset equal to the chosen SLO time range. In certain cases it may happen that very large amount of successful events rotate out of the 4-week SLO time window, resulting to sudden decrease of error budget due to newly changed balance of failed events to all events. \n",
             "mode": "markdown"
           },
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "8.0.2",
           "timeFrom": null,
           "timeShift": null,
-          "title": "",
           "transparent": true,
           "type": "text"
         }
@@ -72,14 +134,7 @@
       "id": 8,
       "panels": [],
       "repeat": "offset",
-      "scopedVars": {
-        "offset": {
-          "selected": false,
-          "text": "0s",
-          "value": "0s"
-        }
-      },
-      "title": "Error budget (offset: $offset)",
+      "title": "Burn rate (offset: $offset)",
       "type": "row"
     },
     {
@@ -90,7 +145,13 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "SLO Effective Burn-rate - ${__field.labels.slo_domain} - ${__field.labels.slo_class} - ${__field.labels.slo_type}",
+              "url": "https://grafana/d/5r2KMMWMk/slo-effective-burn-rate?orgId=1&&var-slo_version=${__field.labels.slo_version}&var-slo_domain=${__field.labels.slo_domain}&var-slo_class=${__field.labels.slo_class}&var-slo_time_range=${__field.labels.slo_time_range}&var-slo_type=All&var-namespace=${__field.labels.namespace}&var-offset=All&var-cluster=All&var-instance=All&${__url_time_range}"
+            }
+          ]
         },
         "overrides": []
       },
@@ -98,7 +159,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 19,
         "x": 0,
         "y": 2
       },
@@ -124,37 +185,34 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.3",
+      "pluginVersion": "8.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "v",
-      "scopedVars": {
-        "offset": {
-          "selected": false,
-          "text": "0s",
-          "value": "0s"
-        }
-      },
       "seriesOverrides": [
         {
-          "alias": "/error budget/",
-          "color": "#5794F2",
+          "$$hashKey": "object:293",
+          "alias": "/burn rate/",
+          "color": "#FF9830",
           "linewidth": 3,
           "zindex": 3
         },
         {
+          "$$hashKey": "object:294",
           "alias": "/fail|success events in 5m/",
           "fill": 1,
           "yaxis": 2,
           "zindex": -3
         },
         {
+          "$$hashKey": "object:295",
           "alias": "/fail.+/",
           "color": "#F2495C"
         },
         {
+          "$$hashKey": "object:296",
           "alias": "/success.+/",
           "color": "#37872D"
         }
@@ -164,29 +222,29 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "slo:violation_ratio{slo_time_range=\"$slo_time_range\", slo_version=\"$slo_version\", slo_domain=~\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=~\"$slo_class\", namespace=\"$namespace\"}\n/ on (slo_domain, slo_class, slo_version, slo_type) group_left ()\n(slo:violation_ratio_threshold - 1)\n+1",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "error budget: {{slo_domain}} {{slo_class}} {{slo_type}}",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(increase(slo_domain_slo_class:slo_events_total{slo_domain=~\"$slo_domain\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_type=~\"$slo_type\", namespace=~\"$namespace\", instance=~\"$instance\", cluster=~\"$cluster\"}[5m])) by (result)",
+          "exemplar": true,
+          "expr": "sum(increase(slo_domain_slo_class:slo_events_total{slo_domain=~\"$slo_domain\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_type=~\"$slo_type\", namespace=~\"$namespace\", instance=~\"$instance\", cluster=~\"$cluster\"}[5m] offset $offset)) by (result)",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{ result }} events in 5m (clusters: $cluster, instances: $instance)",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "slo:burn_rate{slo_time_range=\"$slo_time_range\", slo_version=\"$slo_version\", slo_domain=~\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=~\"$slo_class\", namespace=\"$namespace\"} offset $offset",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SLO burn rate",
+          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": "$offset",
-      "title": "$slo_type error budget ($slo_time_range, offset $offset)",
+      "title": "$slo_type burn-rate (offset $offset)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -202,14 +260,16 @@
       },
       "yaxes": [
         {
-          "format": "percentunit",
+          "$$hashKey": "object:329",
+          "format": "short",
           "label": null,
           "logBase": 1,
-          "max": 1,
+          "max": null,
           "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:330",
           "format": "none",
           "label": null,
           "logBase": 1,
@@ -224,171 +284,190 @@
       }
     },
     {
-      "collapsed": false,
-      "datasource": "Prometheus",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "id": 23,
-      "panels": [],
-      "repeatIteration": 1611139373526,
-      "repeatPanelId": 8,
-      "scopedVars": {
-        "offset": {
-          "selected": false,
-          "text": "1h",
-          "value": "1h"
-        }
-      },
-      "title": "Error budget (offset: $offset)",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit"
         },
         "overrides": []
       },
-      "fill": 0,
-      "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 11
+        "h": 2,
+        "w": 5,
+        "x": 19,
+        "y": 2
       },
-      "hiddenSeries": false,
-      "hideTimeOverride": false,
       "id": 24,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "percentage": false,
-      "pluginVersion": "7.3.3",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeat": null,
-      "repeatDirection": "v",
-      "repeatIteration": 1611139373526,
-      "repeatPanelId": 2,
-      "repeatedByRow": true,
-      "scopedVars": {
-        "offset": {
-          "selected": false,
-          "text": "1h",
-          "value": "1h"
-        }
-      },
-      "seriesOverrides": [
-        {
-          "alias": "/error budget/",
-          "color": "#5794F2",
-          "linewidth": 3,
-          "zindex": 3
-        },
-        {
-          "alias": "/fail|success events in 5m/",
-          "fill": 1,
-          "yaxis": 2,
-          "zindex": -3
-        },
-        {
-          "alias": "/fail.+/",
-          "color": "#F2495C"
-        },
-        {
-          "alias": "/success.+/",
-          "color": "#37872D"
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "8.2.2",
       "targets": [
         {
-          "expr": "slo:violation_ratio{slo_time_range=\"$slo_time_range\", slo_version=\"$slo_version\", slo_domain=~\"$slo_domain\", slo_type=~\"$slo_type\", slo_class=~\"$slo_class\", namespace=\"$namespace\"}\n/ on (slo_domain, slo_class, slo_version, slo_type) group_left ()\n(slo:violation_ratio_threshold - 1)\n+1",
-          "format": "time_series",
+          "exemplar": true,
+          "expr": "delta(slo:error_budget{slo_domain=~\"$slo_domain\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_type=~\"$slo_type\", namespace=~\"$namespace\"}[${__range_s}s] offset $offset)",
           "hide": false,
+          "instant": true,
           "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "error budget: {{slo_domain}} {{slo_class}} {{slo_type}}",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(increase(slo_domain_slo_class:slo_events_total{slo_domain=~\"$slo_domain\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_type=~\"$slo_type\", namespace=~\"$namespace\", instance=~\"$instance\", cluster=~\"$cluster\"}[5m])) by (result)",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{ result }} events in 5m (clusters: $cluster, instances: $instance)",
+          "legendFormat": "",
           "refId": "B"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": "$offset",
-      "title": "$slo_type error budget ($slo_time_range, offset $offset)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": 1,
-          "min": null,
-          "show": true
+      "title": "4w Error budget change on chosen timerange",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 5,
+        "x": 19,
+        "y": 4
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.2",
+      "targets": [
         {
-          "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
+          "exemplar": true,
+          "expr": "sum(increase(slo_domain_slo_class:slo_events_total{slo_domain=~\"$slo_domain\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_type=~\"$slo_type\", namespace=~\"$namespace\", cluster=~\"$cluster\", instance=~\"$instance\", result=\"success\"}[${__range_s}s] offset $offset)) by (slo_domain, slo_class, slo_type, slo_version, namespace, result)",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
         }
       ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "title": "Success events count on chosen timerange",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 5,
+        "x": 19,
+        "y": 6
+      },
+      "id": 28,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(increase(slo_domain_slo_class:slo_events_total{slo_domain=~\"$slo_domain\", slo_class=~\"$slo_class\", slo_version=\"$slo_version\", slo_type=~\"$slo_type\", namespace=~\"$namespace\", cluster=~\"$cluster\", instance=~\"$instance\", result=\"fail\"}[${__range_s}s] offset $offset)) by (slo_domain, slo_class, slo_type, slo_version, namespace, result)",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed events count on chosen timerange",
+      "type": "stat"
     },
     {
       "collapsed": false,
@@ -401,23 +480,19 @@
       },
       "id": 10,
       "panels": [],
-      "title": "Error budget burned on selected time window - by app; by app, event_key",
+      "title": "Failed events count on selected time window - by app; by app, event_key",
       "type": "row"
     },
     {
       "columns": [
         {
+          "$$hashKey": "object:1573",
           "text": "Current",
           "value": "current"
         }
       ],
       "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
+      "description": "",
       "fontSize": "100%",
       "gridPos": {
         "h": 9,
@@ -431,10 +506,11 @@
       "showHeader": true,
       "sort": {
         "col": 1,
-        "desc": false
+        "desc": true
       },
       "styles": [
         {
+          "$$hashKey": "object:49",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -444,14 +520,15 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
+          "decimals": 0,
           "mappingType": 1,
           "pattern": "Current",
           "thresholds": [],
           "type": "number",
-          "unit": "percentunit"
+          "unit": "short"
         },
         {
+          "$$hashKey": "object:50",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -472,7 +549,8 @@
       ],
       "targets": [
         {
-          "expr": "(\n   (\n     ( # violation ratio at the beginning of the dashboard chosen time range\n       clamp_min(\n           sum(\n             increase(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", result=\"fail\"}[$slo_time_range] offset ${__range_s}s)\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app)\n           / on(slo_domain, slo_version, slo_class) group_left()\n           sum(\n             increase(slo_domain_slo_class:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}[$slo_time_range] offset ${__range_s}s)\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace)\n       , 0)\n     )\n     / on (slo_domain, slo_class, slo_version, slo_type) group_left ()\n     (slo:violation_ratio_threshold - 1)\n     # this gets us % (e.g. -0.05 for 5 percent) of error budget burnt by each individual app at the beginning of the time range\n   ) * -1\n   -\n   (\n       ( # violation ratio valid at the end of the dashboard chosen time range\n       clamp_min(\n           sum(\n             increase(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", result=\"fail\"}[$slo_time_range])\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app)\n           / on(slo_domain, slo_version, slo_class) group_left()\n           sum(\n             increase(slo_domain_slo_class:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}[$slo_time_range])\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace)\n       , 0)\n     )\n     / on (slo_domain, slo_class, slo_version, slo_type) group_left ()\n     (slo:violation_ratio_threshold - 1)\n       # this gets us % (e.g. -0.05 for 5 percent) of error budget burnt by each individual app at the end of the displayed time range\n   ) * -1\n)\n",
+          "exemplar": true,
+          "expr": " sum(\n   increase(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", instance=~\"$instance\", cluster=~\"$cluster\", namespace=\"$namespace\", result=\"fail\"}[${__range_s}s])\n ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app)",
           "instant": true,
           "interval": "",
           "legendFormat": "{{ slo_app }}",
@@ -481,24 +559,19 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "By app",
+      "title": "By app (clusters: $cluster, instances: $instance)",
       "transform": "timeseries_aggregations",
       "type": "table-old"
     },
     {
       "columns": [
         {
+          "$$hashKey": "object:103",
           "text": "Current",
           "value": "current"
         }
       ],
       "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "fontSize": "100%",
       "gridPos": {
         "h": 9,
@@ -511,10 +584,11 @@
       "showHeader": true,
       "sort": {
         "col": 1,
-        "desc": false
+        "desc": true
       },
       "styles": [
         {
+          "$$hashKey": "object:105",
           "alias": "",
           "align": "left",
           "colorMode": null,
@@ -523,17 +597,18 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "decimals": 3,
+          "decimals": 0,
           "pattern": "/.*/",
           "thresholds": [],
           "type": "number",
-          "unit": "percentunit"
+          "unit": "short"
         }
       ],
       "targets": [
         {
-          "expr": "(\n   (\n     ( # violation ratio at the beginning of the dashboard chosen time range\n       clamp_min(\n           sum(\n             increase(slo_domain_slo_class_slo_app_event_key:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", result=\"fail\"}[$slo_time_range] offset ${__range_s}s)\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app, event_key)\n           / on(slo_domain, slo_version, slo_class) group_left()\n           sum(\n             increase(slo_domain_slo_class:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}[$slo_time_range] offset ${__range_s}s)\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace)\n       , 0)\n     )\n     / on (slo_domain, slo_class, slo_version, slo_type) group_left ()\n     (slo:violation_ratio_threshold - 1)\n     # this gets us % (e.g. -0.05 for 5 percent) of error budget burnt by each individual app at the beginning of the time range\n   ) * -1\n   -\n   (\n       ( # violation ratio valid at the end of the dashboard chosen time range\n       clamp_min(\n           sum(\n             increase(slo_domain_slo_class_slo_app_event_key:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", result=\"fail\"}[$slo_time_range])\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app, event_key)\n           / on(slo_domain, slo_version, slo_class) group_left()\n           sum(\n             increase(slo_domain_slo_class:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}[$slo_time_range])\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace)\n       , 0)\n     )\n     / on (slo_domain, slo_class, slo_version, slo_type) group_left ()\n     (slo:violation_ratio_threshold - 1)\n       # this gets us % (e.g. -0.05 for 5 percent) of error budget burnt by each individual app at the end of the displayed time range\n   ) * -1\n)\n",
-          "instant": false,
+          "exemplar": true,
+          "expr": " sum(\n   increase(slo_domain_slo_class_slo_app_event_key:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", instance=~\"$instance\", cluster=~\"$cluster\", namespace=\"$namespace\", result=\"fail\"}[${__range_s}s])\n ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app, event_key)",
+          "instant": true,
           "interval": "",
           "legendFormat": "{{ slo_app }}:{{ event_key }}",
           "refId": "A"
@@ -541,12 +616,12 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "By app, event_key",
+      "title": "By app, event_key (clusters: $cluster, instances: $instance)",
       "transform": "timeseries_aggregations",
       "type": "table-old"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
@@ -555,133 +630,128 @@
         "y": 29
       },
       "id": 12,
-      "panels": [],
-      "title": "Error budget burned on selected time window (cluster: $cluster, instances: $instance) - by app; by app, event_key",
+      "panels": [
+        {
+          "columns": [
+            {
+              "$$hashKey": "object:161",
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "Prometheus",
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 4,
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": 1,
+            "desc": true
+          },
+          "styles": [
+            {
+              "$$hashKey": "object:163",
+              "alias": "",
+              "align": "left",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": " sum(\n   increase(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", instance=~\"$instance\", cluster=~\"$cluster\", namespace=\"$namespace\", result=\"fail\"}[${__range_s}s])\n ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app, instance, cluster)",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{ cluster }}:{{ instance }}:{{ slo_app }}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "By cluster, instance, app (clusters: $cluster, instances: $instance)",
+          "transform": "timeseries_aggregations",
+          "type": "table-old"
+        },
+        {
+          "columns": [
+            {
+              "$$hashKey": "object:209",
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "Prometheus",
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 17,
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": 1,
+            "desc": true
+          },
+          "styles": [
+            {
+              "$$hashKey": "object:211",
+              "alias": "",
+              "align": "left",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": " sum(\n   increase(slo_domain_slo_class_slo_app_event_key:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", instance=~\"$instance\", cluster=~\"$cluster\", namespace=\"$namespace\", result=\"fail\"}[${__range_s}s])\n ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app, event_key, instance, cluster)",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{ cluster }}:{{instance}}:{{ slo_app }}:{{ event_key }}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "By cluster, instance, app, event_key (clusters: $cluster, instances: $instance)",
+          "transform": "timeseries_aggregations",
+          "type": "table-old"
+        }
+      ],
+      "title": "Failed events count on selected time window - by app; by app, event_key",
       "type": "row"
-    },
-    {
-      "columns": [
-        {
-          "text": "Current",
-          "value": "current"
-        }
-      ],
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 30
-      },
-      "id": 4,
-      "pageSize": null,
-      "showHeader": true,
-      "sort": {
-        "col": 1,
-        "desc": false
-      },
-      "styles": [
-        {
-          "alias": "",
-          "align": "left",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 3,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "percentunit"
-        }
-      ],
-      "targets": [
-        {
-          "expr": "(\n   (\n     ( # violation ratio at the beginning of the dashboard chosen time range\n       clamp_min(\n           sum(\n             increase(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", result=\"fail\", instance=~\"$instance\", cluster=~\"$cluster\"}[$slo_time_range] offset ${__range_s}s)\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app, instance, cluster)\n           / on(slo_domain, slo_version, slo_class) group_left()\n           sum(\n             increase(slo_domain_slo_class:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}[$slo_time_range] offset ${__range_s}s)\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace)\n       , 0)\n     )\n     / on (slo_domain, slo_class, slo_version, slo_type) group_left ()\n     (slo:violation_ratio_threshold - 1)\n     # this gets us % (e.g. -0.05 for 5 percent) of error budget burnt by each individual app at the beginning of the time range\n   ) * -1\n   -\n   (\n       ( # violation ratio valid at the end of the dashboard chosen time range\n       clamp_min(\n           sum(\n             increase(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", result=\"fail\", instance=~\"$instance\", cluster=~\"$cluster\"}[$slo_time_range])\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app, instance, cluster)\n           / on(slo_domain, slo_version, slo_class) group_left()\n           sum(\n             increase(slo_domain_slo_class:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}[$slo_time_range])\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace)\n       , 0)\n     )\n     / on (slo_domain, slo_class, slo_version, slo_type) group_left ()\n     (slo:violation_ratio_threshold - 1)\n       # this gets us % (e.g. -0.05 for 5 percent) of error budget burnt by each individual app at the end of the displayed time range\n   ) * -1\n)\n",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{ cluster }}:{{ instance }}:{{ slo_app }}",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "By cluster, instance, app",
-      "transform": "timeseries_aggregations",
-      "type": "table-old"
-    },
-    {
-      "columns": [
-        {
-          "text": "Current",
-          "value": "current"
-        }
-      ],
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 30
-      },
-      "id": 17,
-      "pageSize": null,
-      "showHeader": true,
-      "sort": {
-        "col": 1,
-        "desc": false
-      },
-      "styles": [
-        {
-          "alias": "",
-          "align": "left",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 3,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "percentunit"
-        }
-      ],
-      "targets": [
-        {
-          "expr": "(\n   (\n     ( # violation ratio at the beginning of the dashboard chosen time range\n       clamp_min(\n           sum(\n             increase(slo_domain_slo_class_slo_app_event_key:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", result=\"fail\", instance=~\"$instance\", cluster=~\"$cluster\"}[$slo_time_range] offset ${__range_s}s)\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app, event_key, instance, cluster)\n           / on(slo_domain, slo_version, slo_class) group_left()\n           sum(\n             increase(slo_domain_slo_class:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}[$slo_time_range] offset ${__range_s}s)\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace)\n       , 0)\n     )\n     / on (slo_domain, slo_class, slo_version, slo_type) group_left ()\n     (slo:violation_ratio_threshold - 1)\n     # this gets us % (e.g. -0.05 for 5 percent) of error budget burnt by each individual app at the beginning of the time range\n   ) * -1\n   -\n   (\n       ( # violation ratio valid at the end of the dashboard chosen time range\n       clamp_min(\n           sum(\n             increase(slo_domain_slo_class_slo_app_event_key:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", result=\"fail\", instance=~\"$instance\", cluster=~\"$cluster\"}[$slo_time_range])\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace, slo_app, event_key, instance, cluster)\n           / on(slo_domain, slo_version, slo_class) group_left()\n           sum(\n             increase(slo_domain_slo_class:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}[$slo_time_range])\n           ) by (slo_class, slo_domain, slo_version, slo_type, namespace)\n       , 0)\n     )\n     / on (slo_domain, slo_class, slo_version, slo_type) group_left ()\n     (slo:violation_ratio_threshold - 1)\n       # this gets us % (e.g. -0.05 for 5 percent) of error budget burnt by each individual app at the end of the displayed time range\n   ) * -1\n)\n",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{ cluster }}:{{instance}}:{{ slo_app }}:{{ event_key }}",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "By cluster, instance, app, event_key",
-      "transform": "timeseries_aggregations",
-      "type": "table-old"
     }
   ],
   "refresh": false,
-  "schemaVersion": 26,
+  "schemaVersion": 31,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -691,6 +761,7 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:violation_ratio_threshold{}, slo_version)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -698,13 +769,15 @@
         "multi": false,
         "name": "slo_version",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{}, slo_version)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{}, slo_version)",
+          "refId": "Prometheus-slo_version-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -714,6 +787,7 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\"}, slo_domain)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -721,13 +795,15 @@
         "multi": false,
         "name": "slo_domain",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\"}, slo_domain)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\"}, slo_domain)",
+          "refId": "Prometheus-slo_domain-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -737,6 +813,7 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_class)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -744,13 +821,15 @@
         "multi": false,
         "name": "slo_class",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_class)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_class)",
+          "refId": "Prometheus-slo_class-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -760,20 +839,41 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:burn_rate{slo_version=\"$slo_version\"}, slo_time_range)",
-        "error": null,
+        "description": null,
+        "error": {
+          "config": {
+            "headers": {
+              "X-Grafana-Org-Id": 1
+            },
+            "hideFromInspector": true,
+            "method": "GET",
+            "retry": 0,
+            "url": "api/datasources/proxy/20/api/v1/series?match%5B%5D=slo%3Aburn_rate%7Bslo_version%3D%226%22%7D&start=1640274512&end=1640879312"
+          },
+          "data": {
+            "error": "Bad Gateway",
+            "message": "Bad Gateway",
+            "response": ""
+          },
+          "message": "Bad Gateway",
+          "status": 502,
+          "statusText": "Bad Gateway"
+        },
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "slo_time_range",
         "options": [],
-        "query": "label_values(slo:burn_rate{slo_version=\"$slo_version\"}, slo_time_range)",
+        "query": {
+          "query": "label_values(slo:burn_rate{slo_version=\"$slo_version\"}, slo_time_range)",
+          "refId": "Prometheus-slo_time_range-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -783,6 +883,7 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_type)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -790,13 +891,15 @@
         "multi": false,
         "name": "slo_type",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_type)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=\"$slo_version\", slo_domain=\"$slo_domain\"}, slo_type)",
+          "refId": "Prometheus-slo_type-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -806,6 +909,7 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo:violation_ratio_threshold{slo_version=~\"$slo_version\", slo_domain=~\"$slo_domain\"}, namespace)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -813,13 +917,15 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(slo:violation_ratio_threshold{slo_version=~\"$slo_version\", slo_domain=~\"$slo_domain\"}, namespace)",
+        "query": {
+          "query": "label_values(slo:violation_ratio_threshold{slo_version=~\"$slo_version\", slo_domain=~\"$slo_domain\"}, namespace)",
+          "refId": "Prometheus-namespace-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -828,7 +934,8 @@
         "allValue": null,
         "current": {},
         "datasource": "Prometheus",
-        "definition": "query_result(absent({x=\"$slo_time_range\"}) or absent({x=\"0s\"}))",
+        "definition": "query_result(absent({x=\"1s\"}) or absent({x=\"$slo_time_range\"}))",
+        "description": null,
         "error": null,
         "hide": 2,
         "includeAll": true,
@@ -836,22 +943,22 @@
         "multi": true,
         "name": "offset",
         "options": [],
-        "query": "query_result(absent({x=\"$slo_time_range\"}) or absent({x=\"0s\"}))",
+        "query": {
+          "query": "query_result(absent({x=\"1s\"}) or absent({x=\"$slo_time_range\"}))",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "/.*x=\"([^\"]+)\".*/",
         "skipUrlSync": false,
-        "sort": 3,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "sort": 0,
+        "type": "query"
       },
       {
         "allValue": ".*",
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}, cluster)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -859,13 +966,15 @@
         "multi": true,
         "name": "cluster",
         "options": [],
-        "query": "label_values(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}, cluster)",
+        "query": {
+          "query": "label_values(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\"}, cluster)",
+          "refId": "Prometheus-cluster-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -875,6 +984,7 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", cluster=~\"$cluster\"}, instance)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -882,13 +992,15 @@
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", cluster=~\"$cluster\"}, instance)",
+        "query": {
+          "query": "label_values(slo_domain_slo_class_slo_app:slo_events_total{slo_type=\"$slo_type\", slo_domain=\"$slo_domain\", slo_class=\"$slo_class\", namespace=\"$namespace\", cluster=~\"$cluster\"}, instance)",
+          "refId": "Prometheus-instance-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -926,5 +1038,5 @@
   "timezone": "",
   "title": "SLO Drilldown",
   "uid": "rPOkReFMz",
-  "version": 9
+  "version": 6
 }


### PR DESCRIPTION
Syncing Grafana dashboards

Notably, drilldown dashboard has been reworked in order to be more user-friendly.

It now displays total count of success/fail events and 4w error budget on chosen timerange within tables on the right side. The main graph now does display slo-time-range based burn-rate instead of slo-time-range error budget (which is what confused the most users). 