### PR TITLE
fix: Fix file creation and error handling in slo-rules-generator.

### DIFF
--- a/tools/slo-rules-generator/slo-rules-generator.go
+++ b/tools/slo-rules-generator/slo-rules-generator.go
@@ -69,19 +69,25 @@ func main() {
 				os.Exit(2)
 			}
 			fname := fmt.Sprintf("%s.yaml", domainName)
-			f, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE, 0755)
+			f, err := os.Create(fname)
+			if err != nil {
+				fmt.Printf("Error while creating file %s: %v", fname, err)
+				os.Exit(1)
+			}
 			fmt.Printf("-> %s\n", fname)
 			defer f.Close()
 			_, err = f.WriteString(domainFileHeaderComment)
 			if err != nil {
 				fmt.Printf("Error while writing to %s: %v", fname, err)
+				os.Exit(1)
 			}
 			_, err = f.Write(data)
 			if err != nil {
 				fmt.Printf("Error while writing to %s: %v", fname, err)
+				os.Exit(1)
 			}
-		}
 	}
+}
 
 
 


### PR DESCRIPTION
Previously:
 - the files were being created with the executable bits set
 - when writing to an existing file, the file was not truncted, which
   lead to leftover data at the end of the file
 - errors during file creation & writing were either ignored or
   swallowed