### PR TITLE
feat: prometheusIngester sends user-agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Fixed
-- [#96](https://github.com/seznam/slo-exporter/pull/96) prometheusIngester headers from environment value now works
 
-## [v6.12.1] 2022-10-12
+## [v6.12.1] 2022-10-14
 ### Added
 - [#95](https://github.com/seznam/slo-exporter/pull/95) prometheusIngester sends user-agent header
+
+### Fixed
+- [#96](https://github.com/seznam/slo-exporter/pull/96) prometheusIngester headers from environment value now works
 
 ## [v6.12.0] 2022-10-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#96](https://github.com/seznam/slo-exporter/pull/96) prometheusIngester headers from environment value now works
 
+## [v6.12.1] 2022-10-12
+### Added
+- [#95](https://github.com/seznam/slo-exporter/pull/95) prometheusIngester sends user-agent header
+
 ## [v6.12.0] 2022-10-06
 ### Added
 - [#94](https://github.com/seznam/slo-exporter/pull/94) prometheusIngester now can send custom headers to prometheus api server

--- a/cmd/slo_exporter.go
+++ b/cmd/slo_exporter.go
@@ -68,7 +68,7 @@ func moduleFactory(moduleName string, logger logrus.FieldLogger, conf *viper.Vip
 	case "tailer":
 		return tailer.NewFromViper(conf, logger)
 	case "prometheusIngester":
-		return prometheus_ingester.NewFromViper(conf, logger)
+		return prometheus_ingester.NewFromViper(conf, logger, version)
 	case "kafkaIngester":
 		return kafka_ingester.NewFromViper(conf, logger)
 	case "envoyAccessLogServer":

--- a/pkg/prometheus_ingester/prometheus_ingester.go
+++ b/pkg/prometheus_ingester/prometheus_ingester.go
@@ -171,8 +171,13 @@ func (i *PrometheusIngester) OutputChannel() chan *event.Raw {
 	return i.outputChannel
 }
 
-func NewFromViper(viperAppConfig *viper.Viper, logger logrus.FieldLogger) (*PrometheusIngester, error) {
+func NewFromViper(viperAppConfig *viper.Viper, logger logrus.FieldLogger, appVersion string) (*PrometheusIngester, error) {
 	config := PrometheusIngesterConfig{}
+	userAgent := fmt.Sprintf("slo-exporter/%s", appVersion)
+	config.HttpHeaders = append(config.HttpHeaders, httpHeader{
+		Name:  "User-Agent",
+		Value: &userAgent,
+	})
 	if err := viperAppConfig.UnmarshalExact(&config); err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}

--- a/pkg/prometheus_ingester/prometheus_ingester.go
+++ b/pkg/prometheus_ingester/prometheus_ingester.go
@@ -173,14 +173,17 @@ func (i *PrometheusIngester) OutputChannel() chan *event.Raw {
 
 func NewFromViper(viperAppConfig *viper.Viper, logger logrus.FieldLogger, appVersion string) (*PrometheusIngester, error) {
 	config := PrometheusIngesterConfig{}
-	userAgent := fmt.Sprintf("slo-exporter/%s", appVersion)
-	config.HttpHeaders = append(config.HttpHeaders, httpHeader{
-		Name:  "User-Agent",
-		Value: &userAgent,
-	})
+
 	if err := viperAppConfig.UnmarshalExact(&config); err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
+
+	userAgent := "slo-exporter/" + appVersion
+	config.HttpHeaders = append(config.HttpHeaders, httpHeader{
+		Name:  "user-agent",
+		Value: &userAgent,
+	})
+
 	if config.Staleness == time.Duration(0) {
 		config.Staleness = defaultStaleness
 	}


### PR DESCRIPTION
Since prometheusIgester has support for sending headers, we should send by default user-agent header