### PR TITLE
fix: prometheusIngester headers from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- [#96](https://github.com/seznam/slo-exporter/pull/96) prometheusIngester headers from environment value now works
 
 ## [v6.12.0] 2022-10-06
 ### Added

--- a/pkg/prometheus_ingester/prometheus_ingester.go
+++ b/pkg/prometheus_ingester/prometheus_ingester.go
@@ -87,21 +87,13 @@ type httpHeader struct {
 	Value        *string
 }
 
-func (h *httpHeader) validate() error {
+func (h *httpHeader) getValue() (string, error) {
 	if h.Name == "" {
-		return fmt.Errorf("header name must be set")
+		return "", fmt.Errorf("header name must be set")
 	}
 
 	if (h.ValueFromEnv == nil) == (h.Value == nil) {
-		return fmt.Errorf("exactly one of 'Value' or 'ValueFromEnv' must be set")
-	}
-
-	return nil
-}
-
-func (h *httpHeader) getValue() (string, error) {
-	if err := h.validate(); err != nil {
-		return "", err
+		return "", fmt.Errorf("exactly one of 'Value' or 'ValueFromEnv' must be set")
 	}
 
 	if h.ValueFromEnv != nil {
@@ -121,16 +113,16 @@ func (h *httpHeader) getValue() (string, error) {
 type httpHeaders []httpHeader
 
 func (hs httpHeaders) toMap() (map[string]string, error) {
-	httpHeaders := map[string]string{}
+	headersMap := map[string]string{}
 	for _, h := range hs {
 		value, err := h.getValue()
 		if err != nil {
 			return nil, err
 		}
-		httpHeaders[h.Name] = value
+		headersMap[h.Name] = value
 	}
 
-	return httpHeaders, nil
+	return headersMap, nil
 }
 
 type PrometheusIngesterConfig struct {

--- a/pkg/prometheus_ingester/prometheus_ingester_test.go
+++ b/pkg/prometheus_ingester/prometheus_ingester_test.go
@@ -763,38 +763,6 @@ func Test_httpHeaders_toMap(t *testing.T) {
 	}
 }
 
-func Test_httpHeader_validate(t *testing.T) {
-	var headerValue = "value"
-	type fields struct {
-		Name         string
-		ValueFromEnv *httpHeaderValueFromEnv
-		Value        *string
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		wantErr bool
-	}{
-		{name: "header name not set", fields: fields{Name: "", Value: &headerValue}, wantErr: true},
-		{name: "no value neither valueFromEnv set", fields: fields{Name: "headerName"}, wantErr: true},
-		{name: "value", fields: fields{Name: "headerName", Value: &headerValue}, wantErr: false},
-		{name: "valueFromEnv", fields: fields{Name: "headerName", ValueFromEnv: &httpHeaderValueFromEnv{Name: "envName"}}, wantErr: false},
-		{name: "value and valueFromEnv", fields: fields{Name: "headerName", ValueFromEnv: &httpHeaderValueFromEnv{}, Value: &headerValue}, wantErr: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			h := &httpHeader{
-				Name:         tt.fields.Name,
-				ValueFromEnv: tt.fields.ValueFromEnv,
-				Value:        tt.fields.Value,
-			}
-			if err := h.validate(); (err != nil) != tt.wantErr {
-				t.Errorf("httpHeader.validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
 func Test_httpHeader_getValue(t *testing.T) {
 	var headerName = "headerName"
 	var headerValue = "headerValue"
@@ -832,6 +800,9 @@ func Test_httpHeader_getValue(t *testing.T) {
 			want: headerValueFromEnvPrefix + headerValueFromEnvValue},
 		{name: "valueFromEnv non existing env", fields: fields{Name: headerName, ValueFromEnv: &httpHeaderValueFromEnv{Name: nonExistingEnv}}, wantErr: true},
 		{name: "valueFromEnv no env name set", fields: fields{Name: headerName, ValueFromEnv: &httpHeaderValueFromEnv{}}, wantErr: true},
+		{name: "header name not set", fields: fields{Name: "", Value: &headerValue}, wantErr: true},
+		{name: "no value neither valueFromEnv set", fields: fields{Name: headerName}, wantErr: true},
+		{name: "value and valueFromEnv", fields: fields{Name: headerName, ValueFromEnv: &httpHeaderValueFromEnv{}, Value: &headerValue}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -845,9 +816,7 @@ func Test_httpHeader_getValue(t *testing.T) {
 				t.Errorf("httpHeader.getValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("httpHeader.getValue() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/prometheus_ingester/prometheus_ingester_test.go
+++ b/pkg/prometheus_ingester/prometheus_ingester_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/seznam/slo-exporter/pkg/stringmap"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
 )
 
 type MockedRoundTripper struct {
@@ -721,113 +720,15 @@ func Test_processHistogramIncrease(t *testing.T) {
 	}
 }
 
-func TestPrometheusIngesterHttpHeader_UnmarshalYAML(t *testing.T) {
-	const envName = "ENVNAME"
-	var expectedValue = "value"
-	var expectedValueWithPrefix = "xxxvalue"
-
-	if err := os.Unsetenv("NON_EXISTING_ENV_NAME"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Setenv(envName, expectedValue); err != nil {
-		t.Fatal(err)
-	}
-
-	tests := []struct {
-		name          string
-		data          []byte
-		expectedValue *string
-		wantErr       bool
-	}{
-		{
-			name: "value from string",
-			data: []byte(`
-name: name
-value: value
-`),
-			expectedValue: &expectedValue,
-		},
-		{
-			name: "value from env",
-			data: []byte(`
-name: name
-valueFromEnv:
-  name: ENVNAME
-`),
-			expectedValue: &expectedValue,
-		},
-		{
-			name: "value from env with no env name",
-			data: []byte(`
-name: name
-valueFromEnv: {}
-`),
-			wantErr: true,
-		},
-		{
-			name: "value from env with valuePrefix",
-			data: []byte(`
-name: name
-valueFromEnv:
-  name: ENVNAME
-  valuePrefix: xxx
-`),
-			expectedValue: &expectedValueWithPrefix,
-		},
-		{
-			name: "both valueFromString and valueFromEnv is set",
-			data: []byte(`
-name: name
-valueFromEnv: 
-  name: ENVNAME
-value: value
-`),
-			wantErr: true,
-		},
-		{
-			name:    "none of valueFromString or valueFromEnv is set",
-			data:    []byte("name: name"),
-			wantErr: true,
-		},
-		{
-			name:    "none of valueFromString or valueFromEnv is set",
-			data:    []byte("value: value"),
-			wantErr: true,
-		},
-		{
-			name: "non existing environment variable with name valueFromEnv",
-			data: []byte(`
-name: name
-valueFromEnv:
-  name: NON_EXISTING_ENV_NAME
-`),
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			h := httpHeader{}
-			err := yaml.Unmarshal(tt.data, &h)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("PrometheusIngesterHttpHeader.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if err == nil {
-				assert.EqualValues(t, tt.expectedValue, h.Value)
-			}
-		})
-	}
-}
-
 func Test_httpHeaders_toMap(t *testing.T) {
 	var headerValue = "value"
 	var headerValue2 = "value2"
 
 	tests := []struct {
-		name string
-		hs   httpHeaders
-		want map[string]string
+		name    string
+		hs      httpHeaders
+		want    map[string]string
+		wantErr bool
 	}{
 		{
 			name: "empty headers",
@@ -844,10 +745,109 @@ func Test_httpHeaders_toMap(t *testing.T) {
 			hs:   httpHeaders{{Name: "header1", Value: &headerValue}, {Name: "header2", Value: &headerValue2}, {Name: "header1", Value: &headerValue2}},
 			want: map[string]string{"header1": headerValue2, "header2": headerValue2},
 		},
+		{
+			name:    "validate fail - no header name",
+			hs:      httpHeaders{{Name: "", Value: &headerValue}},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.hs.toMap())
+			got, err := tt.hs.toMap()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("httpHeader.getValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_httpHeader_validate(t *testing.T) {
+	var headerValue = "value"
+	type fields struct {
+		Name         string
+		ValueFromEnv *httpHeaderValueFromEnv
+		Value        *string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{name: "header name not set", fields: fields{Name: "", Value: &headerValue}, wantErr: true},
+		{name: "no value neither valueFromEnv set", fields: fields{Name: "headerName"}, wantErr: true},
+		{name: "value", fields: fields{Name: "headerName", Value: &headerValue}, wantErr: false},
+		{name: "valueFromEnv", fields: fields{Name: "headerName", ValueFromEnv: &httpHeaderValueFromEnv{Name: "envName"}}, wantErr: false},
+		{name: "value and valueFromEnv", fields: fields{Name: "headerName", ValueFromEnv: &httpHeaderValueFromEnv{}, Value: &headerValue}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &httpHeader{
+				Name:         tt.fields.Name,
+				ValueFromEnv: tt.fields.ValueFromEnv,
+				Value:        tt.fields.Value,
+			}
+			if err := h.validate(); (err != nil) != tt.wantErr {
+				t.Errorf("httpHeader.validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_httpHeader_getValue(t *testing.T) {
+	var headerName = "headerName"
+	var headerValue = "headerValue"
+	var headerValueFromEnvValue = "headerValueFromEnv"
+	var headerValueFromEnvPrefix = "Prefix"
+	var envName = "envName"
+	var nonExistingEnv = "NON_EXISTING_ENV_NAME"
+
+	if err := os.Unsetenv(nonExistingEnv); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Setenv(envName, headerValueFromEnvValue); err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		Name         string
+		ValueFromEnv *httpHeaderValueFromEnv
+		Value        *string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    string
+		wantErr bool
+	}{
+		{name: "value", fields: fields{Name: headerName, Value: &headerValue}, want: headerValue},
+		{name: "valueFromEnv", fields: fields{Name: headerName, ValueFromEnv: &httpHeaderValueFromEnv{Name: envName}}, want: headerValueFromEnvValue},
+		{
+			name: "valueFromEnv with prefix",
+			fields: fields{
+				Name:         headerName,
+				ValueFromEnv: &httpHeaderValueFromEnv{Name: envName, ValuePrefix: headerValueFromEnvPrefix}},
+			want: headerValueFromEnvPrefix + headerValueFromEnvValue},
+		{name: "valueFromEnv non existing env", fields: fields{Name: headerName, ValueFromEnv: &httpHeaderValueFromEnv{Name: nonExistingEnv}}, wantErr: true},
+		{name: "valueFromEnv no env name set", fields: fields{Name: headerName, ValueFromEnv: &httpHeaderValueFromEnv{}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &httpHeader{
+				Name:         tt.fields.Name,
+				ValueFromEnv: tt.fields.ValueFromEnv,
+				Value:        tt.fields.Value,
+			}
+			got, err := h.getValue()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("httpHeader.getValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("httpHeader.getValue() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
original implementation counted with viper using yaml library and UnmarshalYAML interface. It was naive, viper uses
mapstructure instead of yaml package