### PR TITLE
fix: handle inconsistent histograms in prometheusIngester before persisting them into previousResult

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ SLO_EXPORTER_BIN ?= slo_exporter
 build:
 	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -o $(SLO_EXPORTER_BIN) -a $(SRC_DIR)/cmd/slo_exporter.go
 
-.PHONY: docker-build
+.PHONY: docker
 docker: build
 	docker build -t slo_exporter .
 

--- a/examples/prometheus/slo_exporter.yaml
+++ b/examples/prometheus/slo_exporter.yaml
@@ -1,29 +1,30 @@
 webServerListenAddress: "0.0.0.0:8080"
 
-pipeline: ["prometheusIngester", "relabel", "eventKeyGenerator", "dynamicClassifier", "sloEventProducer", "prometheusExporter"]
+pipeline:
+  [
+    "prometheusIngester",
+    "relabel",
+    "eventKeyGenerator",
+    "dynamicClassifier",
+    "sloEventProducer",
+    "prometheusExporter",
+  ]
 
 modules:
   prometheusIngester:
     apiUrl: "http://demo.robustperception.io:9090"
-    httpHeaders:
-      - name: X-Scope-OrgID
-        value: "myOrganization"
-      - name: Authorization
-        valueFromEnv:
-          name: "SLO_EXPORTER_AUTH_TOKEN"
-          valuePrefix: "Bearer "
     queryTimeout: 30s
     queries:
       # Generate events from counter for every HTTP request with status code for availability SLO.
       - type: counter_increase
-        query: 'prometheus_http_requests_total'
+        query: "prometheus_http_requests_total"
         interval: 30s
         additionalLabels:
           event_type: http_request_result
 
       # Generate events from histogram for every HTTP request for latency SLO.
       - type: histogram_increase
-        query: 'prometheus_http_request_duration_seconds_bucket'
+        query: "prometheus_http_request_duration_seconds_bucket"
         interval: 30s
         additionalLabels:
           event_type: http_request_latency

--- a/pkg/prometheus_ingester/prometheus_ingester_test.go
+++ b/pkg/prometheus_ingester/prometheus_ingester_test.go
@@ -1012,6 +1012,33 @@ func Test_processHistogramIncrease_inconsistency(t *testing.T) {
 			expectedEvents: []expectedEvent{},
 		},
 		{
+			name: "Inconsistent histogram by values does not produce events",
+			timeSeries: []metricsSlice{
+				{
+					ts: ts,
+					metrics: []metric{
+						{le: "0", value: 0},
+						{le: "1", value: 0},
+						{le: "2", value: 0},
+						{le: "3", value: 0},
+						{le: "+Inf", value: 0},
+					},
+				},
+				{
+					ts: ts.Add(20 * time.Second),
+					metrics: []metric{
+						{le: "0", value: 0},
+						{le: "1", value: 2},
+						{le: "2", value: 6}, // Inconsistent sample from new scrape
+						{le: "3", value: 3},
+						{le: "+Inf", value: 4},
+					},
+					expectError: true,
+				},
+			},
+			expectedEvents: []expectedEvent{},
+		},
+		{
 			name: "Inconsistent histogram slice is ignored and accounted by subsequent valid slice",
 			timeSeries: []metricsSlice{
 				{

--- a/pkg/stringmap/stringmap.go
+++ b/pkg/stringmap/stringmap.go
@@ -54,7 +54,7 @@ func (m StringMap) NewWith(key, value string) StringMap {
 // Keys returns non-ordered list of StringMap keys.
 func (m StringMap) Keys() []string {
 	var keys []string
-	for k, _ := range m {
+	for k := range m {
 		keys = append(keys, k)
 	}
 	return keys

--- a/pkg/stringmap/stringmap.go
+++ b/pkg/stringmap/stringmap.go
@@ -115,7 +115,7 @@ func (m StringMap) Matches(other StringMap) bool {
 	return true
 }
 
-//String returns ordered key-value list separated with comma.
+// String returns ordered key-value list separated with comma.
 func (m StringMap) String() string {
 	items := make([]string, len(m))
 	for i, key := range m.SortedKeys() {


### PR DESCRIPTION
Currently, slo-exporter ignores inconsistent histograms but persist its values as previous result causing malformed data, 
this should hopefully fix it :crossed_fingers: 
