### PR TITLE
feat prometheusIngester: add offset setting for query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v6.13.0] 2023-03-03
+### Added
+- []() prometheusIngester add `offset` option to query, allowing to query bit older data to ensure consistency on prometheus compatible systems using remote write.
+
 ## [v6.12.1] 2022-10-14
 ### Added
 - [#95](https://github.com/seznam/slo-exporter/pull/95) prometheusIngester sends user-agent header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [v6.13.0] 2023-03-03
+## [v6.13.0] 2023-03-07
 ### Added
 - [#101](https://github.com/seznam/slo-exporter/pull/101) prometheusIngester add `offset` option to query, allowing to query bit older data to ensure consistency on prometheus compatible systems using remote write.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v6.13.0] 2023-03-03
 ### Added
-- []() prometheusIngester add `offset` option to query, allowing to query bit older data to ensure consistency on prometheus compatible systems using remote write.
+- [#101](https://github.com/seznam/slo-exporter/pull/101) prometheusIngester add `offset` option to query, allowing to query bit older data to ensure consistency on prometheus compatible systems using remote write.
 
 ## [v6.12.1] 2022-10-14
 ### Added

--- a/docs/modules/prometheus_ingester.md
+++ b/docs/modules/prometheus_ingester.md
@@ -1,10 +1,10 @@
 # Prometheus ingester
 
-|                |                         |
-|----------------|-------------------------|
-| `moduleName`   | `prometheusIngester`    |
-| Module type    | `producer`              |
-| Output event   | `raw`                   |
+|              |                      |
+| ------------ | -------------------- |
+| `moduleName` | `prometheusIngester` |
+| Module type  | `producer`           |
+| Output event | `raw`                |
 
 Prometheus ingester generates events based on results of provided Prometheus queries.
 For its usage example see [the prometheus example](/examples/prometheus).
@@ -56,6 +56,8 @@ type: '<query_type>'
 resultAsQuantity: false
 # How often to execute the query.
 interval: <go_duration>
+# Query data with given offset. Useful to ensure consistency when querying data coming from remote write.
+offset: <go_duration>
 # Names of the labels that should be dropped from the result.
 dropLabels:
   - <label_name>

--- a/examples/prometheus/slo_exporter.yaml
+++ b/examples/prometheus/slo_exporter.yaml
@@ -1,6 +1,14 @@
 webServerListenAddress: "0.0.0.0:8080"
 
-pipeline: ["prometheusIngester", "relabel", "eventKeyGenerator", "dynamicClassifier", "sloEventProducer", "prometheusExporter"]
+pipeline:
+  [
+    "prometheusIngester",
+    "relabel",
+    "eventKeyGenerator",
+    "dynamicClassifier",
+    "sloEventProducer",
+    "prometheusExporter",
+  ]
 
 modules:
   prometheusIngester:
@@ -8,22 +16,23 @@ modules:
     httpHeaders:
       - name: X-Scope-OrgID
         value: "myOrganization"
-      - name: Authorization
-        valueFromEnv:
-          name: "SLO_EXPORTER_AUTH_TOKEN"
-          valuePrefix: "Bearer "
+      # - name: Authorization
+      #   valueFromEnv:
+      #     name: "SLO_EXPORTER_AUTH_TOKEN"
+      #     valuePrefix: "Bearer "
     queryTimeout: 30s
     queries:
       # Generate events from counter for every HTTP request with status code for availability SLO.
       - type: counter_increase
-        query: 'prometheus_http_requests_total'
+        query: "prometheus_http_requests_total"
         interval: 30s
+        offset: 5m
         additionalLabels:
           event_type: http_request_result
 
       # Generate events from histogram for every HTTP request for latency SLO.
       - type: histogram_increase
-        query: 'prometheus_http_request_duration_seconds_bucket'
+        query: "prometheus_http_request_duration_seconds_bucket"
         interval: 30s
         additionalLabels:
           event_type: http_request_latency

--- a/pkg/prometheus_ingester/query_executor.go
+++ b/pkg/prometheus_ingester/query_executor.go
@@ -74,7 +74,7 @@ func (q *queryExecutor) withRangeSelector(ts time.Time) string {
 	return q.Query.Query + fmt.Sprintf("[%ds]", int64(rangeSelector.Seconds()))
 }
 
-// execute query at provided timestamp ts
+// execute query at provided timestamp ts taking the configured query offser into account. Returns the actual timestamp with offset applied.
 func (q *queryExecutor) execute(ts time.Time) (model.Value, time.Time, error) {
 	ts = ts.Add(-q.Query.Offset)
 	q.queryInProgress.Store(true)


### PR DESCRIPTION
We experienced issues when querying data coming from remote write API, especially for `histogram_increase` query types.

This should allow the user to add a safety buffer to ensure the histogram and data consistency.



In addition to it, there were some minor changes needed to allow testability of the feature and fixed some related mutex copying 
