### PR TITLE
fix(ci): remove remote_docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: '20.10.23'
+          version: '20.10.24'
       - attach_workspace:
           at: .
       - run: make docker
@@ -50,7 +50,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: '20.10.23'
+          version: '20.10.24'
       - run: |
           echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USER}" --password-stdin
           make release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: '20.10.24'
       - attach_workspace:
           at: .
       - run: make docker
@@ -50,7 +49,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: '20.10.24'
       - run: |
           echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USER}" --password-stdin
           make release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - [#111](https://github.com/seznam/slo-exporter/pull/111) Add JSON logging support
+- [#113](https://github.com/seznam/slo-exporter/pull/113) Remove docker remote version to use the default circleci version
 
 ## [v6.14.0] 2024-01-22
 ### Changed


### PR DESCRIPTION
### Summary
This PR addresses a build issue caused by an unsupported Docker version on CircleCI. The build failure can be viewed ([here](https://app.circleci.com/pipelines/github/seznam/slo-exporter/376/workflows/affe1c77-d687-4743-bed5-3b31c3cd3604/jobs/1574))
```
Job was rejected because this version of Docker is not supported on this resource class. Try removing the version of Docker in your .circleci/config.yml and re-running
```
### Soluton

Remove the remote docker version to use the circleci default.

> According to CircleCI's [building Docker images documentation](https://circleci.com/docs/building-docker-images/#docker-version) and their [remote Docker image support policy](https://circleci.com/docs/remote-docker-images-support-policy/#tagging), the next supported Docker version is `20.10.24`. However, this version is marked as deprecated, and CircleCI has recommended removing the Docker version specification if possible to avoid future compatibility issues.

### Validation

- [x] Pipeline is **success** [here](https://app.circleci.com/pipelines/circleci/JHBMcE1JKrQaJbWiribN1C/Qik9VmoCzudw1AxX1dkZGw/5/workflows/b737a39e-7533-496b-859b-8e002ea0aeca)