### PR TITLE
Add arm64 / multi-platform support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: '20.10.23'
+          version: '20.10.24'
       - attach_workspace:
           at: .
       - run: make docker
@@ -50,7 +50,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: '20.10.23'
+          version: '20.10.24'
       - run: |
           echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USER}" --password-stdin
           make release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: '20.10.24'
       - attach_workspace:
           at: .
       - run: make docker
@@ -50,7 +49,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: '20.10.24'
       - run: |
           echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USER}" --password-stdin
           make release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
     goarch:
       - amd64
       - 386
+      - arm64
 
     ignore:
     - goos: darwin
@@ -26,10 +27,11 @@ dockers:
   - goos: linux
     goarch: amd64
     image_templates:
-      - seznam/slo-exporter:{{ .Tag }}
-      - seznam/slo-exporter:v{{ .Major }}.{{ .Minor }}
-      - seznam/slo-exporter:v{{ .Major }}
-      - seznam/slo-exporter:latest
+      - seznam/slo-exporter:{{ .Tag }}-amd64
+      - seznam/slo-exporter:v{{ .Major }}.{{ .Minor }}-amd64
+      - seznam/slo-exporter:v{{ .Major }}-amd64
+      - seznam/slo-exporter:latest-amd64
+    use: buildx
     build_flag_templates:
       - --pull
       # Labels according to opencontainers label schema https://github.com/opencontainers/image-spec/blob/master/annotations.md
@@ -43,4 +45,43 @@ dockers:
       - --label=org.opencontainers.image.authors=sklik.devops@firma.seznam.cz
       - --label=org.opencontainers.image.url={{.GitURL}}
       - --label=org.opencontainers.image.documentation={{.GitURL}}
-      - --label=org.opencontainers.image.source={{replace .GitURL ".git" "" }}
+      - "--platform=linux/amd64"
+  - goos: linux
+    goarch: arm64
+    image_templates:
+    - seznam/slo-exporter:{{ .Tag }}-arm64
+    - seznam/slo-exporter:v{{ .Major }}.{{ .Minor }}-arm64
+    - seznam/slo-exporter:v{{ .Major }}-arm64
+    - seznam/slo-exporter:latest-arm64
+    use: buildx
+    build_flag_templates:
+    - --pull
+    # Labels according to opencontainers label schema https://github.com/opencontainers/image-spec/blob/master/annotations.md
+    - --label=org.opencontainers.image.created={{.Date}}
+    - --label=org.opencontainers.image.revision={{.FullCommit}}
+    - --label=org.opencontainers.image.version={{.Version}}
+
+    - --label=org.opencontainers.image.title={{.ProjectName}}
+    - --label=org.opencontainers.image.description=Tool to evaluate and generate standardizedSLO metrics from distinct data sources.
+    - --label=org.opencontainers.image.vendor=Seznam, a.s.
+    - --label=org.opencontainers.image.authors=sklik.devops@firma.seznam.cz
+    - --label=org.opencontainers.image.url={{.GitURL}}
+    - --label=org.opencontainers.image.documentation={{.GitURL}}
+    - "--platform=linux/arm64"
+docker_manifests:
+- name_template: "seznam/slo-exporter:{{ .Tag }}"
+  image_templates:
+  - "seznam/slo-exporter:{{ .Tag }}-amd64"
+  - "seznam/slo-exporter:{{ .Tag }}-arm64"
+- name_template: "seznam/slo-exporter:v{{ .Major }}.{{ .Minor }}"
+  image_templates:
+  - "seznam/slo-exporter:v{{ .Major }}.{{ .Minor }}-amd64"
+  - "seznam/slo-exporter:v{{ .Major }}.{{ .Minor }}-arm64"
+- name_template: "seznam/slo-exporter:v{{ .Major }}"
+  image_templates:
+  - "seznam/slo-exporter:v{{ .Major }}-amd64"
+  - "seznam/slo-exporter:v{{ .Major }}-arm64"
+- name_template: "seznam/slo-exporter:latest"
+  image_templates:
+  - "seznam/slo-exporter:latest-amd64"
+  - "seznam/slo-exporter:latest-arm64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - [#111](https://github.com/seznam/slo-exporter/pull/111) Add JSON logging support
+- [#113](https://github.com/seznam/slo-exporter/pull/113) Remove docker remote version to use the default circleci version
 
 ## [v6.14.0] 2024-01-22
 ### Changed


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

This change add `ARM64` support to slo-exporter. 

Enabling ARM64 support allows it to run on ARM-based architectures, such as Apple M1/M2 chips and many cloud servers, improving compatibility and performance on these platforms. Also, It makes the image usable on a wider range of devices and environments, especially those that prioritize energy efficiency and lower cost.

### Description of the Change

Extend the `goreleaser` setup to consider the multi-platforms and docker manifests. 

### Verification Process

To verify this change:

- Used the recent tag v6.7.1 to republish the release with the arm64 support. see [assets](https://github.com/mohammedalics/slo-exporter/releases/tag/v6.7.1 ) 
- Used my dockerhub to publish the images and make sure the publish process goes as expected. 
   - see [SLO Exporter Dockerhub contains arm64 images](https://hub.docker.com/repository/docker/mohammedalics/slo-exporter/general )
   - see [mohammedalics/slo-exporter:latest
 in linux/arm64 OS/ARCH](https://hub.docker.com/layers/mohammedalics/slo-exporter/latest/images/sha256-876d7bdfff5d1a4f9fb2c2552bef8cd0f2fba1fc8e3c9568f2df6c59c18349f4?context=repo) 
- See circleci successful workflow run [here](https://app.circleci.com/pipelines/circleci/JHBMcE1JKrQaJbWiribN1C/Qik9VmoCzudw1AxX1dkZGw/8/workflows/c6a18a77-ca54-4116-b0c5-c20592ee65f3)

--- 
**Note**: This PR branch was branched from/based on https://github.com/seznam/slo-exporter/pull/113, as fixing the docker build was essential to validate the changes. Once merged, I can rebase this branch/PR. 
