### PR TITLE
add qemu before release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 before:
   hooks:
     - go mod download
+    - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 builds:
   - main: ./cmd/slo_exporter.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- [#115](https://github.com/seznam/slo-exporter/pull/115) Add `qemu` before release to fix the multi-platform release issue.
 
 ## [v6.15.0] 2024-11-06
 


### PR DESCRIPTION
### Why?
This PR is to fix the issue in releasing multi-platform docker images. 

See issue: https://app.circleci.com/pipelines/github/seznam/slo-exporter/384/workflows/932fb8ac-8631-4d2d-a48b-9dbc083055d2/jobs/1603?invite=true#step-103-96 

```
#6 ERROR: process "/bin/sh -c apt-get update && apt-get install ca-certificates -y && apt-get clean" did not complete successfully: exit code: 1
------
 > [2/5] RUN apt-get update && apt-get install ca-certificates -y && apt-get clean:
0.237 exec /bin/sh: exec format error
------
Dockerfile:3
--------------------
   1 |     FROM debian:stable-slim
   2 |     
   3 | >>> RUN apt-get update && apt-get install ca-certificates -y && apt-get clean
   4 |     
   5 |     COPY slo_exporter  /slo_exporter/
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && apt-get install ca-certificates -y && apt-get clean" did not complete successfully: exit code: 1

Learn more at https://goreleaser.com/errors/docker-build

make: *** [Makefile:75: release] Error 1

Exited with code exit status 2
```

### Solution

Adding [qemu](https://www.qemu.org/)

As mentioned in goreleaser documentation [here](https://goreleaser.com/cookbooks/multi-platform-docker-images/#other-things-to-pay-attention-to): 
> For buildx to work properly, you'll need to install qemu